### PR TITLE
Enhance answer screen with dark gameshow layout and scoring

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -7,24 +7,30 @@
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
-  <div class="container">
-    <h1>Admin</h1>
-    <button id="createRoom">Create Room</button>
-    <div id="roomInfo"></div>
-    <div id="setup" style="display:none;">
-      <h2>Setup Categories and Questions</h2>
-      <div id="aiSetup" class="question-block">
-        <input id="apiKey" placeholder="OpenAI API Key">
-        <textarea id="prompt" placeholder="Describe the trivia you want"></textarea>
-        <button id="generate">Generate Questions</button>
+  <div class="admin-wrapper">
+    <div class="container">
+      <h1>Admin</h1>
+      <button id="createRoom">Create Room</button>
+      <div id="roomInfo"></div>
+      <div id="setup" style="display:none;">
+        <h2>Setup Categories and Questions</h2>
+        <div id="aiSetup" class="question-block">
+          <input id="apiKey" placeholder="OpenAI API Key">
+          <textarea id="prompt" placeholder="Describe the trivia you want"></textarea>
+          <button id="generate">Generate Questions</button>
+        </div>
+        <div id="categories"></div>
+        <button id="saveSetup">Save Setup</button>
+        <button id="nextQuestion">Next Question</button>
       </div>
-      <div id="categories"></div>
-      <button id="saveSetup">Save Setup</button>
-      <button id="startQuestion">Start Question</button>
+      <div>
+        <h3>Players:</h3>
+        <ul id="players"></ul>
+      </div>
     </div>
-    <div>
-      <h3>Players:</h3>
-      <ul id="players"></ul>
+    <div id="scorePanel" class="score-panel">
+      <h3>Scores</h3>
+      <ul id="scores"></ul>
     </div>
   </div>
   <script src="/socket.io/socket.io.js"></script>
@@ -41,6 +47,7 @@
       roomCode = code;
       document.getElementById('roomInfo').textContent = 'Room Code: ' + code;
       document.getElementById('setup').style.display = 'block';
+      document.getElementById('nextQuestion').style.display = 'inline';
       buildForm();
     });
 
@@ -86,8 +93,9 @@
       socket.emit('adminSetup', { roomCode, categories });
     };
 
-    document.getElementById('startQuestion').onclick = () => {
+    document.getElementById('nextQuestion').onclick = () => {
       socket.emit('adminStartQuestion', { roomCode });
+      document.getElementById('nextQuestion').style.display = 'none';
     };
 
     document.getElementById('generate').onclick = () => {
@@ -125,11 +133,30 @@
     socket.on('players', list => {
       const ul = document.getElementById('players');
       ul.innerHTML = '';
-      list.forEach(n => {
+      list.forEach(p => {
         const li = document.createElement('li');
-        li.textContent = n;
+        li.textContent = p.name + ' ';
+        const btn = document.createElement('button');
+        btn.textContent = 'Remove';
+        btn.onclick = () => socket.emit('adminRemovePlayer', { roomCode, playerId: p.id });
+        li.appendChild(btn);
         ul.appendChild(li);
       });
+    });
+
+    socket.on('scoreboard', scores => {
+      const ul = document.getElementById('scores');
+      ul.innerHTML = '';
+      scores.forEach(s => {
+        const li = document.createElement('li');
+        li.textContent = s.name + ': ' + s.score;
+        if (s.leader) li.classList.add('leader');
+        ul.appendChild(li);
+      });
+    });
+
+    socket.on('allAnswered', () => {
+      document.getElementById('nextQuestion').style.display = 'inline';
     });
 
     socket.on('roomClosed', () => {

--- a/public/answer.html
+++ b/public/answer.html
@@ -6,15 +6,19 @@
   <title>Answer Screen</title>
   <link rel="stylesheet" href="/style.css">
 </head>
-<body>
-  <div class="container">
-    <h1>Answer Screen</h1>
-    <div id="join" class="question-block">
-      Room Code: <input id="room"><button id="joinBtn">Join</button>
+<body class="answer-screen">
+  <div id="join" class="join-block">
+    Room Code: <input id="room"><button id="joinBtn">Join</button>
+  </div>
+  <div id="display" class="answer-display" style="display:none;">
+    <div id="main" class="main-area">
+      <div id="category" class="category-label"></div>
+      <div id="question" class="question-text"></div>
+      <ul id="answers" class="answers-list"></ul>
     </div>
-    <div id="display" style="display:none;">
-      <div id="question" class="question-block"></div>
-      <ul id="answers"></ul>
+    <div id="scorePanel" class="scoreboard">
+      <h2>Scores</h2>
+      <ul id="scores"></ul>
     </div>
   </div>
   <script src="/socket.io/socket.io.js"></script>
@@ -27,22 +31,35 @@
     document.getElementById('joinBtn').onclick = () => {
       roomCode = document.getElementById('room').value.toUpperCase();
       socket.emit('viewerJoin', { roomCode });
-      document.getElementById('join').style.display='none';
-      document.getElementById('display').style.display='block';
+      document.getElementById('join').style.display = 'none';
+      document.getElementById('display').style.display = 'flex';
     };
 
     socket.on('question', q => {
-      document.getElementById('question').textContent = q.category + ': ' + q.text;
-      document.getElementById('answers').innerHTML='';
+      document.getElementById('category').textContent = q.category;
+      document.getElementById('question').textContent = q.text;
+      document.getElementById('answers').innerHTML = '';
       currentOptions = q.options;
     });
 
     socket.on('playerAnswered', data => {
       const li = document.createElement('li');
       const text = currentOptions[data.answer] || letters[data.answer];
-      li.textContent = data.name + ': ' + text;
+      const seconds = (data.time / 1000).toFixed(2);
+      li.textContent = `${data.name}: ${text} (${seconds}s)`;
       li.className = data.correct ? 'correct' : 'incorrect';
       document.getElementById('answers').appendChild(li);
+    });
+
+    socket.on('scores', list => {
+      const ul = document.getElementById('scores');
+      ul.innerHTML = '';
+      list.sort((a, b) => b.score - a.score);
+      list.forEach(p => {
+        const li = document.createElement('li');
+        li.textContent = `${p.name}: ${p.score}`;
+        ul.appendChild(li);
+      });
     });
 
     socket.on('roomClosed', () => {

--- a/public/player.html
+++ b/public/player.html
@@ -15,15 +15,18 @@
       <button id="joinBtn">Join</button>
     </div>
     <div id="game" style="display:none;">
-      <div id="question" class="question-block"></div>
-      <button id="buzz">Buzz!</button>
-      <div id="options" style="display:none;"></div>
+      <div id="category" class="category"></div>
+      <div id="question" class="question-block question-text"></div>
+      <div id="options" class="options" style="display:none;"></div>
+      <button id="buzz" class="buzz-btn">Buzz!</button>
     </div>
   </div>
   <script src="/socket.io/socket.io.js"></script>
   <script>
     const socket = io();
     let roomCode = null;
+    let buzzedIn = false;
+    let selectedAnswer = null;
 
     document.getElementById('joinBtn').onclick = () => {
       roomCode = document.getElementById('room').value.toUpperCase();
@@ -37,30 +40,52 @@
     });
 
     socket.on('question', q => {
-      document.getElementById('question').textContent = q.category + ': ' + q.text;
-      document.getElementById('options').style.display='none';
-      document.getElementById('buzz').style.display='inline';
+      document.getElementById('category').textContent = q.category;
+      document.getElementById('question').textContent = q.text;
       const optsDiv = document.getElementById('options');
+      optsDiv.style.display='none';
       optsDiv.innerHTML='';
       q.options.forEach((opt, idx) => {
         const btn = document.createElement('button');
         btn.textContent = opt;
         btn.className='option';
         btn.onclick = () => {
-          socket.emit('playerAnswer', { roomCode, answer: idx });
-          document.getElementById('options').style.display='none';
+          selectedAnswer = idx;
+          document.querySelectorAll('.option').forEach(b => b.classList.remove('selected'));
+          btn.classList.add('selected');
         };
         optsDiv.appendChild(btn);
       });
+      selectedAnswer = null;
+      buzzedIn = false;
+      document.getElementById('buzz').textContent = 'Buzz!';
+      document.getElementById('buzz').style.display='block';
     });
 
     document.getElementById('buzz').onclick = () => {
-      socket.emit('playerBuzz', { roomCode });
+      if (!buzzedIn) {
+        socket.emit('playerBuzz', { roomCode });
+      } else {
+        if (selectedAnswer !== null) {
+          socket.emit('playerAnswer', { roomCode, answer: selectedAnswer });
+          document.getElementById('options').style.display='none';
+          document.getElementById('buzz').style.display='none';
+        } else {
+          alert('Select an answer');
+        }
+      }
     };
 
     socket.on('buzzAccepted', () => {
-      document.getElementById('buzz').style.display='none';
+      buzzedIn = true;
+      document.getElementById('buzz').textContent = 'Submit';
       document.getElementById('options').style.display='block';
+    });
+
+
+    socket.on('removed', () => {
+      alert('You have been removed from the game');
+      location.reload();
     });
 
     socket.on('roomClosed', () => {

--- a/public/style.css
+++ b/public/style.css
@@ -1,25 +1,39 @@
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Trebuchet MS', sans-serif;
   margin: 0;
   padding: 1rem;
-  background: #f5f5f5;
+  background: radial-gradient(circle at top, #1a237e, #000);
+  color: #fff;
+}
+.admin-wrapper { display: flex; gap: 1rem; }
+.container {
+  max-width: 600px;
+  margin: 0;
+  flex: 1;
 }
 .container {
   max-width: 600px;
   margin: 0 auto;
 }
 button {
-  background: #6200ea;
+  background: #ff4081;
   color: white;
   border: none;
   padding: 0.5rem 1rem;
   margin: 0.25rem 0;
   border-radius: 4px;
+  box-shadow: 0 0 5px #ff4081, 0 0 10px #ff4081;
 }
 button.option {
   display: block;
   width: 100%;
   margin: 0.25rem 0;
+  font-size: 1.25rem;
+  font-weight: bold;
+}
+button.option.selected {
+  background: green;
+  color: white;
 }
 input, textarea {
   width: 100%;
@@ -28,15 +42,44 @@ input, textarea {
   box-sizing: border-box;
 }
 .question-block {
-  background: white;
+  background: #212121;
   border-radius: 4px;
   padding: 0.5rem;
   margin-bottom: 0.5rem;
+  box-shadow: 0 0 5px #fff;
 }
 .correct { color: green; }
 .incorrect { color: red; }
 @media (max-width: 600px) {
   body { padding: 0.5rem; }
+}
+.question-text {
+  font-size: 2rem;
+  font-weight: bold;
+  text-align: center;
+  margin-top: 60px;
+}
+.category {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+.buzz-btn {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: calc(100% - 40px);
+  max-width: 600px;
+  font-size: 1.5rem;
+  padding: 1rem;
+  border-radius: 30px;
+  z-index: 100;
+}
+.options {
+  margin-bottom: 80px;
 }
 
 /* Answer screen styles */
@@ -133,6 +176,18 @@ body.answer-screen {
   padding: 0.25rem 0;
   border-bottom: 1px solid rgba(255,255,255,0.2);
 }
+
+.score-panel {
+  min-width: 200px;
+  background: #111;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 0 10px #ff4081; 
+  height: fit-content;
+}
+.score-panel ul { list-style: none; padding: 0; }
+.score-panel li { margin: 0.25rem 0; }
+.score-panel li.leader { color: #ffd700; font-weight: bold; }
 
 .join-block {
   background: rgba(0,0,0,0.8);

--- a/public/style.css
+++ b/public/style.css
@@ -38,3 +38,104 @@ input, textarea {
 @media (max-width: 600px) {
   body { padding: 0.5rem; }
 }
+
+/* Answer screen styles */
+body.answer-screen {
+  background: #121212;
+  color: #fff;
+  height: 100vh;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-family: 'Trebuchet MS', sans-serif;
+}
+
+.answer-display {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+.main-area {
+  flex: 1;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.category-label {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  background: rgba(255,255,255,0.1);
+  padding: 0.5rem 1rem;
+  border-radius: 12px;
+  font-size: 1.5rem;
+}
+
+.question-text {
+  font-size: 3rem;
+  font-weight: bold;
+  text-align: center;
+  max-width: 80%;
+}
+
+.answers-list {
+  list-style: none;
+  padding: 0;
+  margin-top: 2rem;
+  width: 80%;
+  display: flex;
+  flex-direction: column;
+}
+
+.answers-list li {
+  margin: 0.5rem 0;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  font-size: 1.25rem;
+  color: #fff;
+  max-width: 60%;
+}
+
+.answers-list li.correct {
+  background: #1e8e3e;
+  align-self: flex-end;
+}
+
+.answers-list li.incorrect {
+  background: #b3261e;
+  align-self: flex-start;
+}
+
+.scoreboard {
+  width: 250px;
+  background: rgba(255,255,255,0.1);
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+.scoreboard h2 {
+  text-align: center;
+  margin-top: 0;
+}
+
+.scoreboard ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.scoreboard li {
+  padding: 0.25rem 0;
+  border-bottom: 1px solid rgba(255,255,255,0.2);
+}
+
+.join-block {
+  background: rgba(0,0,0,0.8);
+  padding: 1rem;
+  border-radius: 8px;
+}

--- a/server.js
+++ b/server.js
@@ -10,6 +10,23 @@ app.use(express.static('public'));
 
 const rooms = {};
 
+function emitPlayers(roomCode) {
+  const room = rooms[roomCode];
+  if (!room) return;
+  const list = Object.entries(room.players).map(([id, p]) => ({ id, name: p.name }));
+  io.to(room.admin).emit('players', list);
+}
+
+function emitScoreboard(roomCode) {
+  const room = rooms[roomCode];
+  if (!room) return;
+  const scores = Object.values(room.players).map(p => ({ name: p.name, score: p.score }));
+  scores.sort((a, b) => b.score - a.score);
+  const top = scores.length ? scores[0].score : 0;
+  const data = scores.map(s => ({ ...s, leader: s.score === top && top > 0 }));
+  io.to(room.admin).emit('scoreboard', data);
+}
+
 function generateRoomCode() {
   return Math.random().toString(36).substring(2, 6).toUpperCase();
 }
@@ -114,11 +131,8 @@ io.on('connection', socket => {
       p.answer = null;
       p.correct = null;
     });
-    io.to(roomCode).emit('question', {
-      category: room.categories[sel.ci].name,
-      text: q.text,
-      options: q.options
-    });
+    emitPlayers(roomCode);
+    emitScoreboard(roomCode);
   });
 
   socket.on('playerJoin', ({ roomCode, name }) => {
@@ -172,6 +186,10 @@ io.on('connection', socket => {
     const time = room.questionStart ? Date.now() - room.questionStart : 0;
     io.to(roomCode).emit('playerAnswered', { name: player.name, answer, correct, time });
     io.to(roomCode).emit('scores', Object.values(room.players).map(p => ({ name: p.name, score: p.score })));
+      emitScoreboard(roomCode);
+    if (Object.values(room.players).every(p => p.answered)) {
+      io.to(room.admin).emit('allAnswered');
+    }
   });
 
   socket.on('disconnect', () => {
@@ -179,7 +197,8 @@ io.on('connection', socket => {
       if (room.players[socket.id]) {
         delete room.players[socket.id];
         io.to(code).emit('players', Object.values(room.players).map(p => p.name));
-        io.to(code).emit('scores', Object.values(room.players).map(p => ({ name: p.name, score: p.score })));
+         emitPlayers(code);
+        emitScoreboard(code);
       }
       if (room.admin === socket.id) {
         io.to(code).emit('roomClosed');
@@ -187,6 +206,20 @@ io.on('connection', socket => {
       }
     }
   });
+
+    socket.on('adminRemovePlayer', ({ roomCode, playerId }) => {
+    const room = rooms[roomCode];
+    if (!room || !room.players[playerId]) return;
+    const psocket = io.sockets.sockets.get(playerId);
+    if (psocket) {
+      psocket.leave(roomCode);
+      psocket.emit('removed');
+    }
+    delete room.players[playerId];
+    emitPlayers(roomCode);
+    emitScoreboard(roomCode);
+  });
+
 });
 
 const PORT = process.env.PORT || 3000;

--- a/server.js
+++ b/server.js
@@ -107,6 +107,7 @@ io.on('connection', socket => {
     const idx = Math.floor(Math.random() * room.remaining.length);
     const sel = room.remaining.splice(idx, 1)[0];
     room.current = sel;
+    room.questionStart = Date.now();
     const q = room.categories[sel.ci].questions[sel.qi];
     Object.values(room.players).forEach(p => {
       p.answered = false;
@@ -130,11 +131,14 @@ io.on('connection', socket => {
     socket.join(roomCode);
     socket.emit('joined', roomCode);
     io.to(roomCode).emit('players', Object.values(room.players).map(p => p.name));
+    io.to(roomCode).emit('scores', Object.values(room.players).map(p => ({ name: p.name, score: p.score })));
   });
 
   socket.on('viewerJoin', ({ roomCode }) => {
     if (rooms[roomCode]) {
       socket.join(roomCode);
+      const room = rooms[roomCode];
+      socket.emit('scores', Object.values(room.players).map(p => ({ name: p.name, score: p.score })));
     } else {
       console.error(`viewerJoin: room ${roomCode} not found`);
     }
@@ -165,7 +169,9 @@ io.on('connection', socket => {
     player.answer = answer;
     player.correct = correct;
     if (correct) player.score += 1;
-    io.to(roomCode).emit('playerAnswered', { name: player.name, answer, correct });
+    const time = room.questionStart ? Date.now() - room.questionStart : 0;
+    io.to(roomCode).emit('playerAnswered', { name: player.name, answer, correct, time });
+    io.to(roomCode).emit('scores', Object.values(room.players).map(p => ({ name: p.name, score: p.score })));
   });
 
   socket.on('disconnect', () => {
@@ -173,6 +179,7 @@ io.on('connection', socket => {
       if (room.players[socket.id]) {
         delete room.players[socket.id];
         io.to(code).emit('players', Object.values(room.players).map(p => p.name));
+        io.to(code).emit('scores', Object.values(room.players).map(p => ({ name: p.name, score: p.score })));
       }
       if (room.admin === socket.id) {
         io.to(code).emit('roomClosed');


### PR DESCRIPTION
## Summary
- overhaul answer display with dark gameshow theme, centered question, category badge, and scoreboard panel
- track question start time and emit player answer times plus updated scores
- style answers to slide left/right with green/red backgrounds for correct and incorrect responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd3e9f8710832bad252b6b6ec5f150