### PR TITLE
Add game show styling and admin controls

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
+  <div id="roomCodeDisplay" class="room-code" style="display:none;"></div>
   <div class="container">
     <h1>Admin</h1>
     <button id="createRoom">Create Room</button>
@@ -21,12 +22,17 @@
       </div>
       <div id="categories"></div>
       <button id="saveSetup">Save Setup</button>
-      <button id="startQuestion">Start Question</button>
+      <button id="nextQuestion" style="display:none;">Start Question</button>
     </div>
     <div>
       <h3>Players:</h3>
       <ul id="players"></ul>
     </div>
+  </div>
+  <div id="scorePanel" class="side-panel" style="display:none;">
+    <h3>Scores</h3>
+    <div id="leader"></div>
+    <ul id="scoreList"></ul>
   </div>
   <script src="/socket.io/socket.io.js"></script>
   <script>
@@ -41,7 +47,11 @@
     socket.on('roomCreated', code => {
       roomCode = code;
       document.getElementById('roomInfo').textContent = 'Room Code: ' + code;
+      const rc = document.getElementById('roomCodeDisplay');
+      rc.textContent = code;
+      rc.style.display = 'block';
       document.getElementById('setup').style.display = 'block';
+      document.getElementById('scorePanel').style.display = 'block';
       buildForm();
     });
 
@@ -85,10 +95,14 @@
         }
       }
       socket.emit('adminSetup', { roomCode, categories });
+      const btn = document.getElementById('nextQuestion');
+      btn.textContent = 'Start Question';
+      btn.style.display = 'block';
     };
 
-    document.getElementById('startQuestion').onclick = () => {
+    document.getElementById('nextQuestion').onclick = () => {
       socket.emit('adminStartQuestion', { roomCode });
+      document.getElementById('nextQuestion').style.display = 'none';
     };
 
     document.getElementById('generate').onclick = () => {
@@ -126,11 +140,32 @@
     socket.on('players', list => {
       const ul = document.getElementById('players');
       ul.innerHTML = '';
-      list.forEach(n => {
+      list.forEach(p => {
         const li = document.createElement('li');
-        li.textContent = n;
+        li.textContent = p.name + ' ';
+        const btn = document.createElement('button');
+        btn.textContent = 'Remove';
+        btn.onclick = () => socket.emit('adminRemovePlayer', { roomCode, playerId: p.id });
+        li.appendChild(btn);
         ul.appendChild(li);
       });
+    });
+
+    socket.on('scores', list => {
+      const ul = document.getElementById('scoreList');
+      ul.innerHTML = '';
+      list.forEach(s => {
+        const li = document.createElement('li');
+        li.textContent = s.name + ': ' + s.score;
+        ul.appendChild(li);
+      });
+      document.getElementById('leader').textContent = list.length ? ('Leader: ' + list[0].name) : '';
+    });
+
+    socket.on('allAnswered', () => {
+      const btn = document.getElementById('nextQuestion');
+      btn.textContent = 'Next Question';
+      btn.style.display = 'block';
     });
 
     socket.on('roomClosed', () => {

--- a/public/answer.html
+++ b/public/answer.html
@@ -8,14 +8,20 @@
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
+  <div id="roomCodeDisplay" class="room-code" style="display:none;"></div>
   <div class="container">
     <h1>Answer Screen</h1>
     <div id="join" class="question-block">
       Room Code: <input id="room"><button id="joinBtn">Join</button>
     </div>
-    <div id="display" style="display:none;">
-      <div id="question" class="question-block"></div>
-      <ul id="answers"></ul>
+  </div>
+  <div id="display" class="presentation" style="display:none;">
+    <div id="catDisplay" class="category-tag" style="left:10px; right:auto;"></div>
+    <div id="question" class="question-display"></div>
+    <ul id="answers" class="answers-list"></ul>
+    <div id="scorePanel" class="side-panel">
+      <h3>Scores</h3>
+      <ul id="scoreList"></ul>
     </div>
   </div>
   <script src="/socket.io/socket.io.js"></script>
@@ -30,10 +36,14 @@
       socket.emit('viewerJoin', { roomCode });
       document.getElementById('join').style.display='none';
       document.getElementById('display').style.display='block';
+      const rc = document.getElementById('roomCodeDisplay');
+      rc.textContent = roomCode;
+      rc.style.display = 'block';
     };
 
     socket.on('question', q => {
-      document.getElementById('question').textContent = q.category + ': ' + q.text;
+      document.getElementById('catDisplay').textContent = q.category;
+      document.getElementById('question').textContent = q.text;
       document.getElementById('answers').innerHTML='';
       currentOptions = q.options;
     });
@@ -41,9 +51,20 @@
     socket.on('playerAnswered', data => {
       const li = document.createElement('li');
       const text = currentOptions[data.answer] || letters[data.answer];
-      li.textContent = data.name + ': ' + text;
+      const secs = (data.time/1000).toFixed(2) + 's';
+      li.textContent = data.name + ': ' + text + ' (' + secs + ')';
       li.className = data.correct ? 'correct' : 'incorrect';
       document.getElementById('answers').appendChild(li);
+    });
+
+    socket.on('scores', list => {
+      const ul = document.getElementById('scoreList');
+      ul.innerHTML = '';
+      list.forEach(s => {
+        const li = document.createElement('li');
+        li.textContent = s.name + ': ' + s.score;
+        ul.appendChild(li);
+      });
     });
 
     socket.on('roomClosed', () => {

--- a/public/player.html
+++ b/public/player.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
+  <div id="roomCodeDisplay" class="room-code" style="display:none;"></div>
   <div class="container">
     <h1>Player</h1>
     <div id="join" class="question-block">
@@ -15,16 +16,18 @@
       Name: <input id="name"><br>
       <button id="joinBtn">Join</button>
     </div>
-    <div id="game" style="display:none;">
-      <div id="question" class="question-block"></div>
-      <button id="buzz">Buzz!</button>
-      <div id="options" style="display:none;"></div>
+    <div id="game" style="display:none; position:relative;">
+      <div id="category" class="category-tag"></div>
+      <div id="question" class="question-block question-display"></div>
+      <div id="options" class="options-list" style="display:none;"></div>
     </div>
+    <button id="buzz" class="buzz-btn">Buzz!</button>
   </div>
   <script src="/socket.io/socket.io.js"></script>
   <script>
     const socket = io();
     let roomCode = null;
+    let selectedAnswer = null;
 
     document.getElementById('joinBtn').onclick = () => {
       roomCode = document.getElementById('room').value.toUpperCase();
@@ -35,33 +38,60 @@
     socket.on('joined', code => {
       document.getElementById('join').style.display='none';
       document.getElementById('game').style.display='block';
+      const rc = document.getElementById('roomCodeDisplay');
+      rc.textContent = code;
+      rc.style.display = 'block';
     });
 
     socket.on('question', q => {
-      document.getElementById('question').textContent = q.category + ': ' + q.text;
-      document.getElementById('options').style.display='none';
-      document.getElementById('buzz').style.display='inline';
+      selectedAnswer = null;
+      document.getElementById('category').textContent = q.category;
+      document.getElementById('question').textContent = q.text;
       const optsDiv = document.getElementById('options');
+      optsDiv.style.display='none';
       optsDiv.innerHTML='';
       q.options.forEach((opt, idx) => {
         const btn = document.createElement('button');
         btn.textContent = opt;
         btn.className='option';
         btn.onclick = () => {
-          socket.emit('playerAnswer', { roomCode, answer: idx });
-          document.getElementById('options').style.display='none';
+          document.querySelectorAll('#options .option').forEach(b=>b.classList.remove('selected'));
+          btn.classList.add('selected');
+          selectedAnswer = idx;
+          const buzz = document.getElementById('buzz');
+          buzz.disabled = false;
         };
         optsDiv.appendChild(btn);
       });
+      const buzz = document.getElementById('buzz');
+      buzz.textContent = 'Buzz!';
+      buzz.dataset.mode = 'buzz';
+      buzz.style.display = 'block';
+      buzz.disabled = false;
     });
 
     document.getElementById('buzz').onclick = () => {
-      socket.emit('playerBuzz', { roomCode });
+      const btn = document.getElementById('buzz');
+      if (btn.dataset.mode === 'buzz') {
+        socket.emit('playerBuzz', { roomCode });
+      } else if (btn.dataset.mode === 'submit' && selectedAnswer !== null) {
+        socket.emit('playerAnswer', { roomCode, answer: selectedAnswer });
+        document.getElementById('options').style.display='none';
+        btn.style.display='none';
+      }
     };
 
     socket.on('buzzAccepted', () => {
-      document.getElementById('buzz').style.display='none';
+      const buzz = document.getElementById('buzz');
+      buzz.textContent = 'Submit';
+      buzz.dataset.mode = 'submit';
+      buzz.disabled = true;
       document.getElementById('options').style.display='block';
+    });
+
+    socket.on('removed', () => {
+      alert('You have been removed from the room');
+      location.reload();
     });
 
     socket.on('roomClosed', () => {

--- a/public/style.css
+++ b/public/style.css
@@ -70,6 +70,96 @@ input, textarea, select {
 .correct { color: var(--correct); }
 .incorrect { color: var(--incorrect); }
 
+.room-code {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  background: #1E90FF;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  font-weight: bold;
+  z-index: 1000;
+}
+
+.side-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 200px;
+  height: 100%;
+  background: var(--surface);
+  padding: 1rem;
+  box-shadow: -2px 0 8px rgba(0,0,0,0.5);
+  overflow-y: auto;
+}
+
+.buzz-btn {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 80%;
+  max-width: 400px;
+}
+
+.category-tag {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: rgba(255,255,255,0.1);
+  border-radius: 8px;
+  padding: 0.25rem 0.5rem;
+  font-weight: bold;
+}
+
+.question-display {
+  font-size: 1.5rem;
+  font-weight: bold;
+  text-align: center;
+  background: rgba(255,255,255,0.1);
+  border-radius: 8px;
+}
+
+.options-list .option {
+  font-size: 1.2rem;
+  font-weight: bold;
+}
+
+.options-list .option.selected {
+  background: var(--correct);
+}
+
+.presentation {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.answers-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem;
+}
+
+.answers-list li {
+  padding: 0.5rem;
+  border-radius: 8px;
+  width: 45%;
+  margin: 0.5rem;
+}
+
+.answers-list li.correct {
+  background: var(--correct);
+  margin-left: auto;
+  text-align: right;
+}
+
+.answers-list li.incorrect {
+  background: var(--incorrect);
+  margin-right: auto;
+  text-align: left;
+}
+
 @media (max-width: 600px) {
   body { padding: 0.5rem; }
 }

--- a/server.js
+++ b/server.js
@@ -10,6 +10,27 @@ app.use(express.static('public'));
 
 const rooms = {};
 
+function getScores(room) {
+  const scores = Object.entries(room.players).map(([id, p]) => ({ id, name: p.name, score: p.score }));
+  scores.sort((a, b) => b.score - a.score);
+  return scores;
+}
+
+function emitPlayers(roomCode) {
+  const room = rooms[roomCode];
+  if (!room) return;
+  const list = Object.entries(room.players).map(([id, p]) => ({ id, name: p.name }));
+  io.to(room.admin).emit('players', list);
+}
+
+function emitScores(roomCode) {
+  const room = rooms[roomCode];
+  if (!room) return;
+  const scores = getScores(room);
+  io.to(room.admin).emit('scores', scores);
+  io.to(roomCode).emit('scores', scores);
+}
+
 function generateRoomCode() {
   return Math.random().toString(36).substring(2, 6).toUpperCase();
 }
@@ -107,11 +128,13 @@ io.on('connection', socket => {
     const idx = Math.floor(Math.random() * room.remaining.length);
     const sel = room.remaining.splice(idx, 1)[0];
     room.current = sel;
+    room.questionStart = Date.now();
     const q = room.categories[sel.ci].questions[sel.qi];
     Object.values(room.players).forEach(p => {
       p.answered = false;
       p.answer = null;
       p.correct = null;
+      p.time = null;
     });
     io.to(roomCode).emit('question', {
       category: room.categories[sel.ci].name,
@@ -129,7 +152,8 @@ io.on('connection', socket => {
     room.players[socket.id] = { name, score: 0, answered: false };
     socket.join(roomCode);
     socket.emit('joined', roomCode);
-    io.to(roomCode).emit('players', Object.values(room.players).map(p => p.name));
+    emitPlayers(roomCode);
+    emitScores(roomCode);
 
     // If a question is already active, send it to the newly joined player
     if (room.current) {
@@ -156,6 +180,7 @@ io.on('connection', socket => {
           options: q.options
         });
       }
+      emitScores(roomCode);
     } else {
       console.error(`viewerJoin: room ${roomCode} not found`);
     }
@@ -163,6 +188,21 @@ io.on('connection', socket => {
 
   socket.on('playerBuzz', ({ roomCode }) => {
     socket.emit('buzzAccepted');
+  });
+
+  socket.on('adminRemovePlayer', ({ roomCode, playerId }) => {
+    const room = rooms[roomCode];
+    if (!room) return;
+    if (room.players[playerId]) {
+      const target = io.sockets.sockets.get(playerId);
+      if (target) {
+        target.leave(roomCode);
+        target.emit('removed');
+      }
+      delete room.players[playerId];
+      emitPlayers(roomCode);
+      emitScores(roomCode);
+    }
   });
 
   socket.on('playerAnswer', ({ roomCode, answer }) => {
@@ -185,15 +225,22 @@ io.on('connection', socket => {
     player.answered = true;
     player.answer = answer;
     player.correct = correct;
+    player.time = Date.now() - room.questionStart;
     if (correct) player.score += 1;
-    io.to(roomCode).emit('playerAnswered', { name: player.name, answer, correct });
+    io.to(roomCode).emit('playerAnswered', { name: player.name, answer, correct, time: player.time });
+    emitScores(roomCode);
+    const allAnswered = Object.values(room.players).every(p => p.answered);
+    if (allAnswered) {
+      io.to(room.admin).emit('allAnswered');
+    }
   });
 
   socket.on('disconnect', () => {
     for (const [code, room] of Object.entries(rooms)) {
       if (room.players[socket.id]) {
         delete room.players[socket.id];
-        io.to(code).emit('players', Object.values(room.players).map(p => p.name));
+        emitPlayers(code);
+        emitScores(code);
       }
       if (room.admin === socket.id) {
         io.to(code).emit('roomClosed');


### PR DESCRIPTION
## Summary
- Add scoreboard utilities and player removal support on server
- Redesign admin page with player removal, score panel, and next question flow
- Refresh player and answer screens with mobile-friendly buzzer, category tags, and dark mode presentation

## Testing
- `npm test`
- `node server.js` (fails without deps, installed with `npm install` and reran)

------
https://chatgpt.com/codex/tasks/task_e_68bd47ab7210832b91258a600af48665