### PR TITLE
Improve trivia screen layouts

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -9,6 +9,8 @@
 </head>
 <body>
   <div id="roomCodeDisplay" class="room-code" style="display:none;"></div>
+  <div id="playerScore" class="player-score" style="display:none;"></div>
+  <div id="submittedMsg" class="submitted-msg" style="display:none;">Question has been submitted.</div>
   <div class="container">
     <h1>Player</h1>
     <div id="join" class="question-block">
@@ -16,8 +18,8 @@
       Name: <input id="name"><br>
       <button id="joinBtn">Join</button>
     </div>
-    <div id="game" style="display:none; position:relative;">
-      <div id="category" class="category-tag"></div>
+    <div id="game" style="display:none; position:relative; padding-top:60px;">
+      <div id="category" class="category-tag" style="left:10px; right:auto; position:fixed; display:none;"></div>
       <div id="question" class="question-block question-display"></div>
       <div id="options" class="options-list" style="display:none;"></div>
     </div>
@@ -28,6 +30,15 @@
     const socket = io();
     let roomCode = null;
     let selectedAnswer = null;
+
+    socket.on('scores', list => {
+      const me = list.find(s => s.id === socket.id);
+      if (me) {
+        const sd = document.getElementById('playerScore');
+        sd.textContent = 'Score: ' + me.score;
+        sd.style.display = 'block';
+      }
+    });
 
     document.getElementById('joinBtn').onclick = () => {
       roomCode = document.getElementById('room').value.toUpperCase();
@@ -45,8 +56,11 @@
 
     socket.on('question', q => {
       selectedAnswer = null;
-      document.getElementById('category').textContent = q.category;
+      const cat = document.getElementById('category');
+      cat.textContent = q.category;
+      cat.style.display = 'block';
       document.getElementById('question').textContent = q.text;
+      document.getElementById('submittedMsg').style.display = 'none';
       const optsDiv = document.getElementById('options');
       optsDiv.style.display='none';
       optsDiv.innerHTML='';
@@ -78,6 +92,7 @@
         socket.emit('playerAnswer', { roomCode, answer: selectedAnswer });
         document.getElementById('options').style.display='none';
         btn.style.display='none';
+        document.getElementById('submittedMsg').style.display = 'block';
       }
     };
 

--- a/public/style.css
+++ b/public/style.css
@@ -121,6 +121,13 @@ input, textarea, select {
   border-radius: 8px;
 }
 
+.presentation .question-display {
+  font-size: 4rem;
+  padding: 0.5rem 1rem;
+  display: inline-block;
+  margin-top: 1rem;
+}
+
 .options-list .option {
   font-size: 1.2rem;
   font-weight: bold;
@@ -144,20 +151,42 @@ input, textarea, select {
 .answers-list li {
   padding: 0.5rem;
   border-radius: 8px;
-  width: 45%;
-  margin: 0.5rem;
+  width: 80%;
+  margin: 0.5rem auto;
+  text-align: center;
+  font-weight: bold;
+  color: #fff;
 }
 
 .answers-list li.correct {
   background: var(--correct);
-  margin-left: auto;
-  text-align: right;
 }
 
 .answers-list li.incorrect {
   background: var(--incorrect);
-  margin-right: auto;
-  text-align: left;
+}
+
+.player-score {
+  position: fixed;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1E90FF;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  font-weight: bold;
+  z-index: 1000;
+}
+
+.submitted-msg {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 1.5rem;
+  font-weight: bold;
+  text-align: center;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Center and bold answer list items with white text
- Enlarge answer screen question and tighten its background box
- Show player score at top center, move category to top left, and display submission confirmation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd4d082f70832b89479d1a4e96c223