### PR TITLE
Add timers, option shuffling, and UI enhancements

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -21,12 +21,18 @@
         <button id="generate">Generate Questions</button>
       </div>
       <div id="categories"></div>
-      <button id="saveSetup">Save Setup</button>
+      <div>
+        <button id="saveSetup">Save Setup</button>
+        <select id="savedSetups"></select>
+      </div>
+      <label><input type="checkbox" id="randomize"> Randomize answers</label>
+      <input id="timeLimit" type="number" placeholder="Time limit (seconds)">
       <button id="nextQuestion" style="display:none;">Start Question</button>
     </div>
     <div>
       <h3>Players:</h3>
       <ul id="players"></ul>
+      <button id="toggleScores" style="display:none;">Toggle Scores</button>
     </div>
   </div>
   <div id="scorePanel" class="side-panel" style="display:none;">
@@ -52,7 +58,9 @@
       rc.style.display = 'block';
       document.getElementById('setup').style.display = 'block';
       document.getElementById('scorePanel').style.display = 'block';
+      document.getElementById('toggleScores').style.display = 'block';
       buildForm();
+      refreshSaved();
     });
 
     function buildForm(){
@@ -95,13 +103,20 @@
         }
       }
       socket.emit('adminSetup', { roomCode, categories });
+      const name = prompt('Name this setup');
+      if (name) {
+        localStorage.setItem('setup_' + name, JSON.stringify(categories));
+        refreshSaved();
+      }
       const btn = document.getElementById('nextQuestion');
       btn.textContent = 'Start Question';
       btn.style.display = 'block';
     };
 
     document.getElementById('nextQuestion').onclick = () => {
-      socket.emit('adminStartQuestion', { roomCode });
+      const randomize = document.getElementById('randomize').checked;
+      const tl = parseInt(document.getElementById('timeLimit').value, 10);
+      socket.emit('adminStartQuestion', { roomCode, randomize, timeLimit: isNaN(tl) ? null : tl });
       document.getElementById('nextQuestion').style.display = 'none';
     };
 
@@ -137,6 +152,44 @@
       alert('Generation failed: ' + msg);
     });
 
+    function refreshSaved() {
+      const sel = document.getElementById('savedSetups');
+      sel.innerHTML = '<option value="">Load Setup</option>';
+      for (let i=0;i<localStorage.length;i++) {
+        const key = localStorage.key(i);
+        if (key.startsWith('setup_')) {
+          const opt = document.createElement('option');
+          opt.value = key;
+          opt.textContent = key.substring(6);
+          sel.appendChild(opt);
+        }
+      }
+    }
+
+    document.getElementById('savedSetups').onchange = e => {
+      const key = e.target.value;
+      if (!key) return;
+      const data = JSON.parse(localStorage.getItem(key));
+      generatedData = data;
+      const categoriesDiv = document.getElementById('categories');
+      categoriesDiv.innerHTML = '';
+      data.forEach(cat => {
+        const catDiv = document.createElement('div');
+        catDiv.className = 'question-block';
+        catDiv.innerHTML = '<h3>'+cat.name+'</h3>';
+        cat.questions.forEach(q => {
+          const qDiv = document.createElement('div');
+          qDiv.className = 'question-block';
+          qDiv.innerHTML = '<strong>'+q.text+'</strong><ul>' + q.options.map((o,i)=>'<li'+(i===q.answer?' class="correct"':'')+'>'+o+'</li>').join('') + '</ul>';
+          catDiv.appendChild(qDiv);
+        });
+        categoriesDiv.appendChild(catDiv);
+      });
+    };
+
+    document.getElementById('toggleScores').onclick = () => {
+      document.getElementById('scorePanel').classList.toggle('collapsed');
+    };
     socket.on('players', list => {
       const ul = document.getElementById('players');
       ul.innerHTML = '';

--- a/public/answer.html
+++ b/public/answer.html
@@ -10,7 +10,6 @@
 <body>
   <div id="roomCodeDisplay" class="room-code" style="display:none;"></div>
   <div class="container">
-    <h1>Answer Screen</h1>
     <div id="join" class="question-block">
       Room Code: <input id="room"><button id="joinBtn">Join</button>
     </div>
@@ -18,7 +17,12 @@
   <div id="display" class="presentation" style="display:none;">
     <div id="catDisplay" class="category-tag" style="left:10px; right:auto;"></div>
     <div id="question" class="question-display"></div>
-    <ul id="answers" class="answers-list"></ul>
+    <div id="progress" class="progress-container" style="display:none;"><div id="progressBar" class="progress-bar"></div></div>
+    <div id="timer" class="timer" style="display:none;"></div>
+    <div id="answers" class="answers-columns">
+      <div class="column"><h2>Correct</h2><ul id="correctList" class="answers-list"></ul></div>
+      <div class="column"><h2>Incorrect</h2><ul id="incorrectList" class="answers-list"></ul></div>
+    </div>
     <div id="scorePanel" class="side-panel">
       <h3>Scores</h3>
       <ul id="scoreList"></ul>
@@ -30,6 +34,10 @@
     const letters = ['A','B','C','D'];
     let roomCode = null;
     let currentOptions = [];
+    let playerCount = 0;
+    let answered = 0;
+    let timerInterval = null;
+    let progressInterval = null;
 
     document.getElementById('joinBtn').onclick = () => {
       roomCode = document.getElementById('room').value.toUpperCase();
@@ -44,20 +52,55 @@
     socket.on('question', q => {
       document.getElementById('catDisplay').textContent = q.category;
       document.getElementById('question').textContent = q.text;
-      document.getElementById('answers').innerHTML='';
+      document.getElementById('correctList').innerHTML='';
+      document.getElementById('incorrectList').innerHTML='';
       currentOptions = q.options;
+      answered = 0;
+      // timer
+      const timerDiv = document.getElementById('timer');
+      timerDiv.style.display='block';
+      clearInterval(timerInterval);
+      timerInterval = setInterval(()=>{
+        timerDiv.textContent = ((Date.now() - q.startTime)/1000).toFixed(1)+'s';
+      },100);
+      // progress bar
+      const prog = document.getElementById('progress');
+      const bar = document.getElementById('progressBar');
+      if (q.timeLimit) {
+        prog.style.display='block';
+        const end = q.startTime + q.timeLimit;
+        clearInterval(progressInterval);
+        progressInterval = setInterval(()=>{
+          const remain = Math.max(0, end - Date.now());
+          bar.style.width = (remain / q.timeLimit * 100) + '%';
+          if (remain <= 0) clearInterval(progressInterval);
+        },100);
+      } else {
+        prog.style.display='none';
+      }
     });
 
     socket.on('playerAnswered', data => {
       const li = document.createElement('li');
       const text = currentOptions[data.answer] || letters[data.answer];
       const secs = (data.time/1000).toFixed(2) + 's';
-      li.textContent = data.name + ': ' + text + ' (' + secs + ')';
+      li.textContent = data.name + ': ' + text;
+      const chip = document.createElement('span');
+      chip.className='time-chip';
+      chip.textContent=secs;
+      li.appendChild(chip);
       li.className = data.correct ? 'correct' : 'incorrect';
-      document.getElementById('answers').appendChild(li);
+      const target = data.correct ? 'correctList' : 'incorrectList';
+      document.getElementById(target).appendChild(li);
+      answered++;
+      if (answered >= playerCount) {
+        clearInterval(timerInterval);
+        clearInterval(progressInterval);
+      }
     });
 
     socket.on('scores', list => {
+      playerCount = list.length;
       const ul = document.getElementById('scoreList');
       ul.innerHTML = '';
       list.forEach(s => {

--- a/public/player.html
+++ b/public/player.html
@@ -12,7 +12,6 @@
   <div id="playerScore" class="player-score" style="display:none;"></div>
   <div id="submittedMsg" class="submitted-msg" style="display:none;">Question has been submitted.</div>
   <div class="container">
-    <h1>Player</h1>
     <div id="join" class="question-block">
       Room Code: <input id="room"><br>
       Name: <input id="name"><br>
@@ -21,6 +20,7 @@
     <div id="game" style="display:none; position:relative; padding-top:60px;">
       <div id="category" class="category-tag" style="left:10px; right:auto; position:fixed; display:none;"></div>
       <div id="question" class="question-block question-display"></div>
+      <div id="progress" class="progress-container" style="display:none;"><div id="progressBar" class="progress-bar"></div></div>
       <div id="options" class="options-list" style="display:none;"></div>
     </div>
     <button id="buzz" class="buzz-btn">Buzz!</button>
@@ -30,6 +30,7 @@
     const socket = io();
     let roomCode = null;
     let selectedAnswer = null;
+    let progressInterval = null;
 
     socket.on('scores', list => {
       const me = list.find(s => s.id === socket.id);
@@ -82,6 +83,20 @@
       buzz.dataset.mode = 'buzz';
       buzz.style.display = 'block';
       buzz.disabled = false;
+      const prog = document.getElementById('progress');
+      const bar = document.getElementById('progressBar');
+      if (q.timeLimit) {
+        prog.style.display='block';
+        const end = q.startTime + q.timeLimit;
+        clearInterval(progressInterval);
+        progressInterval = setInterval(()=>{
+          const remain = Math.max(0, end - Date.now());
+          bar.style.width = (remain / q.timeLimit * 100) + '%';
+          if (remain <= 0) clearInterval(progressInterval);
+        },100);
+      } else {
+        prog.style.display='none';
+      }
     });
 
     document.getElementById('buzz').onclick = () => {

--- a/public/style.css
+++ b/public/style.css
@@ -92,6 +92,11 @@ input, textarea, select {
   padding: 1rem;
   box-shadow: -2px 0 8px rgba(0,0,0,0.5);
   overflow-y: auto;
+  transition: transform 0.3s ease;
+}
+
+.side-panel.collapsed {
+  transform: translateX(100%);
 }
 
 .buzz-btn {
@@ -164,6 +169,45 @@ input, textarea, select {
 
 .answers-list li.incorrect {
   background: var(--incorrect);
+}
+
+.answers-columns {
+  display: flex;
+  gap: 2rem;
+}
+
+.answers-columns .column {
+  flex: 1;
+}
+
+.time-chip {
+  background: var(--accent);
+  color: #fff;
+  padding: 0 6px;
+  border-radius: 12px;
+  margin-left: 8px;
+  font-size: 0.8rem;
+}
+
+.timer {
+  font-size: 2rem;
+  margin-top: 1rem;
+  text-align: center;
+}
+
+.progress-container {
+  width: 100%;
+  background: #555;
+  height: 10px;
+  border-radius: 5px;
+  overflow: hidden;
+  margin: 10px 0;
+}
+
+.progress-bar {
+  height: 100%;
+  background: var(--accent);
+  width: 100%;
 }
 
 .player-score {

--- a/server.js
+++ b/server.js
@@ -119,7 +119,7 @@ io.on('connection', socket => {
     }
   });
 
-  socket.on('adminStartQuestion', ({ roomCode }) => {
+  socket.on('adminStartQuestion', ({ roomCode, randomize, timeLimit }) => {
     const room = rooms[roomCode];
     if (!room || room.remaining.length === 0) {
       console.error(`adminStartQuestion: room ${roomCode} not found or no questions remaining`);
@@ -127,19 +127,37 @@ io.on('connection', socket => {
     }
     const idx = Math.floor(Math.random() * room.remaining.length);
     const sel = room.remaining.splice(idx, 1)[0];
-    room.current = sel;
-    room.questionStart = Date.now();
     const q = room.categories[sel.ci].questions[sel.qi];
+
+    let options = [...q.options];
+    let answer = q.answer;
+    if (randomize) {
+      const arr = options.map((o, i) => ({ o, i }));
+      for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+      }
+      options = arr.map(a => a.o);
+      answer = arr.findIndex(a => a.i === q.answer);
+    }
+
+    room.current = { ci: sel.ci, qi: sel.qi, options, answer };
+    room.questionStart = Date.now();
+    room.timeLimit = timeLimit ? timeLimit * 1000 : null;
+
     Object.values(room.players).forEach(p => {
       p.answered = false;
       p.answer = null;
       p.correct = null;
       p.time = null;
     });
+
     io.to(roomCode).emit('question', {
       category: room.categories[sel.ci].name,
       text: q.text,
-      options: q.options
+      options,
+      timeLimit: room.timeLimit,
+      startTime: room.questionStart
     });
   });
 
@@ -161,7 +179,9 @@ io.on('connection', socket => {
       socket.emit('question', {
         category: room.categories[room.current.ci].name,
         text: q.text,
-        options: q.options
+        options: room.current.options,
+        timeLimit: room.timeLimit,
+        startTime: room.questionStart
       });
     }
   });
@@ -177,7 +197,9 @@ io.on('connection', socket => {
         socket.emit('question', {
           category: room.categories[room.current.ci].name,
           text: q.text,
-          options: q.options
+          options: room.current.options,
+          timeLimit: room.timeLimit,
+          startTime: room.questionStart
         });
       }
       emitScores(roomCode);
@@ -220,8 +242,7 @@ io.on('connection', socket => {
       console.warn(`playerAnswer: player ${socket.id} already answered`);
       return;
     }
-    const q = room.categories[room.current.ci].questions[room.current.qi];
-    const correct = answer === q.answer;
+    const correct = answer === room.current.answer;
     player.answered = true;
     player.answer = answer;
     player.correct = correct;


### PR DESCRIPTION
## Summary
- Allow admin to randomize answer order and impose per-question time limits while emitting start times to clients.
- Enable saving and loading setups via dropdown and collapse/expand of the score side panel.
- Overhaul player and answer screens with progress bars, answer columns, timers, and display cleanup.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd51e470a8832bb007ad7cc4fa2559