### PR TITLE
Add question timer, standings panel, and mini-game

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -78,8 +78,37 @@
           qDiv.innerHTML = 'Question: <input class="qtext"><br>Option A:<input class="opt" data-idx="0"><br>Option B:<input class="opt" data-idx="1"><br>Option C:<input class="opt" data-idx="2"><br>Option D:<input class="opt" data-idx="3"><br>Correct:<select class="correct"><option value="0">A</option><option value="1">B</option><option value="2">C</option><option value="3">D</option></select>';
           qsDiv.appendChild(qDiv);
         }
-        categoriesDiv.appendChild(catDiv);
+      categoriesDiv.appendChild(catDiv);
       }
+    }
+
+    function renderEditable(data) {
+      const categoriesDiv = document.getElementById('categories');
+      categoriesDiv.innerHTML = '';
+      data.forEach((cat, ci) => {
+        const catDiv = document.createElement('div');
+        catDiv.className = 'question-block';
+        catDiv.innerHTML = '<h3>'+cat.name+'</h3>';
+        cat.questions.forEach((q, qi) => {
+          const qDiv = document.createElement('div');
+          qDiv.className = 'question-block';
+          qDiv.innerHTML = '<strong>'+q.text+'</strong> <button class="editQ">Edit</button><ul>' + q.options.map((o,i)=>'<li'+(i===q.answer?' class="correct"':'')+'>'+o+'</li>').join('') + '</ul>';
+          qDiv.querySelector('.editQ').onclick = () => {
+            qDiv.innerHTML = 'Question: <input class="qtext" value="'+q.text+'"><br>' +
+              q.options.map((o,i)=>'Option '+String.fromCharCode(65+i)+':<input class="opt" data-idx="'+i+'" value="'+o+'"><br>').join('') +
+              'Correct:<select class="correct">'+ q.options.map((o,i)=>'<option value="'+i+'"'+(i===q.answer?' selected':'')+'>'+String.fromCharCode(65+i)+'</option>').join('') + '</select><br><button class="saveQ">Save</button>';
+            qDiv.querySelector('.saveQ').onclick = () => {
+              q.text = qDiv.querySelector('.qtext').value;
+              q.options = Array.from(qDiv.querySelectorAll('.opt')).map(i=>i.value);
+              q.answer = parseInt(qDiv.querySelector('.correct').value,10);
+              renderEditable(data);
+              socket.emit('adminSetup', { roomCode, categories: data });
+            };
+          };
+          catDiv.appendChild(qDiv);
+        });
+        categoriesDiv.appendChild(catDiv);
+      });
     }
 
     document.getElementById('saveSetup').onclick = () => {
@@ -132,20 +161,7 @@
 
     socket.on('generatedQuestions', data => {
       generatedData = data;
-      const categoriesDiv = document.getElementById('categories');
-      categoriesDiv.innerHTML = '';
-      data.forEach(cat => {
-        const catDiv = document.createElement('div');
-        catDiv.className = 'question-block';
-        catDiv.innerHTML = '<h3>'+cat.name+'</h3>';
-        cat.questions.forEach(q => {
-          const qDiv = document.createElement('div');
-          qDiv.className = 'question-block';
-          qDiv.innerHTML = '<strong>'+q.text+'</strong><ul>' + q.options.map((o,i)=>'<li'+(i===q.answer?' class="correct"':'')+'>'+o+'</li>').join('') + '</ul>';
-          catDiv.appendChild(qDiv);
-        });
-        categoriesDiv.appendChild(catDiv);
-      });
+      renderEditable(generatedData);
     });
 
     socket.on('generationError', msg => {
@@ -171,20 +187,7 @@
       if (!key) return;
       const data = JSON.parse(localStorage.getItem(key));
       generatedData = data;
-      const categoriesDiv = document.getElementById('categories');
-      categoriesDiv.innerHTML = '';
-      data.forEach(cat => {
-        const catDiv = document.createElement('div');
-        catDiv.className = 'question-block';
-        catDiv.innerHTML = '<h3>'+cat.name+'</h3>';
-        cat.questions.forEach(q => {
-          const qDiv = document.createElement('div');
-          qDiv.className = 'question-block';
-          qDiv.innerHTML = '<strong>'+q.text+'</strong><ul>' + q.options.map((o,i)=>'<li'+(i===q.answer?' class="correct"':'')+'>'+o+'</li>').join('') + '</ul>';
-          catDiv.appendChild(qDiv);
-        });
-        categoriesDiv.appendChild(catDiv);
-      });
+      renderEditable(generatedData);
       socket.emit('adminSetup', { roomCode, categories: data });
       const btn = document.getElementById('nextQuestion');
       btn.textContent = 'Start Question';

--- a/public/admin.html
+++ b/public/admin.html
@@ -185,6 +185,10 @@
         });
         categoriesDiv.appendChild(catDiv);
       });
+      socket.emit('adminSetup', { roomCode, categories: data });
+      const btn = document.getElementById('nextQuestion');
+      btn.textContent = 'Start Question';
+      btn.style.display = 'block';
     };
 
     document.getElementById('toggleScores').onclick = () => {
@@ -214,13 +218,6 @@
       });
       document.getElementById('leader').textContent = list.length ? ('Leader: ' + list[0].name) : '';
     });
-
-    socket.on('allAnswered', () => {
-      const btn = document.getElementById('nextQuestion');
-      btn.textContent = 'Next Question';
-      btn.style.display = 'block';
-    });
-
     socket.on('roomClosed', () => {
       alert('Room closed');
     });

--- a/public/answer.html
+++ b/public/answer.html
@@ -18,7 +18,6 @@
     <div id="catDisplay" class="category-tag" style="left:10px; right:auto;"></div>
     <div id="question" class="question-display"></div>
     <div id="progress" class="progress-container" style="display:none;"><div id="progressBar" class="progress-bar"></div></div>
-    <div id="timer" class="timer" style="display:none;"></div>
     <div id="answers" class="answers-columns">
       <div class="column"><h2>Correct</h2><ul id="correctList" class="answers-list"></ul></div>
       <div class="column"><h2>Incorrect</h2><ul id="incorrectList" class="answers-list"></ul></div>
@@ -36,7 +35,6 @@
     let currentOptions = [];
     let playerCount = 0;
     let answered = 0;
-    let timerInterval = null;
     let progressInterval = null;
 
     document.getElementById('joinBtn').onclick = () => {
@@ -56,13 +54,6 @@
       document.getElementById('incorrectList').innerHTML='';
       currentOptions = q.options;
       answered = 0;
-      // timer
-      const timerDiv = document.getElementById('timer');
-      timerDiv.style.display='block';
-      clearInterval(timerInterval);
-      timerInterval = setInterval(()=>{
-        timerDiv.textContent = ((Date.now() - q.startTime)/1000).toFixed(1)+'s';
-      },100);
       // progress bar
       const prog = document.getElementById('progress');
       const bar = document.getElementById('progressBar');
@@ -94,7 +85,6 @@
       document.getElementById(target).appendChild(li);
       answered++;
       if (answered >= playerCount) {
-        clearInterval(timerInterval);
         clearInterval(progressInterval);
       }
     });

--- a/public/player.html
+++ b/public/player.html
@@ -31,6 +31,8 @@
     </div>
     <div id="miniGame" class="question-block" style="display:none; text-align:center;">
       <h2>Run!</h2>
+      <div id="miniInstructions" style="margin-bottom:10px;">Alternate tapping Left and Right or use the ← → arrow keys!</div>
+      <div id="miniCountdown" class="countdown" style="display:none;"></div>
       <div id="miniProgress" class="progress-container" style="display:none;">
         <div id="miniProgressBar" class="progress-bar"></div>
       </div>
@@ -52,6 +54,8 @@
     let lastRun = null;
     let miniGameActive = false;
     let runDistance = 0;
+    let miniGameReady = false;
+    let miniCountdownTimer = null;
 
     socket.on('scores', list => {
       const me = list.find(s => s.id === socket.id);
@@ -168,40 +172,69 @@
       alert('Room closed');
     });
 
-    socket.on('miniGameStart', ({ duration, startTime }) => {
+    socket.on('miniGameStart', ({ duration, startTime, countdown = 0 }) => {
       document.getElementById('game').style.display = 'none';
       document.getElementById('standingsPanel').style.display = 'none';
       const mg = document.getElementById('miniGame');
       mg.style.display = 'block';
       lastRun = null;
       miniGameActive = true;
-       runDistance = 0;
-       document.getElementById('miniDistance').textContent = '0 m';
+      miniGameReady = false;
+      runDistance = 0;
+      document.getElementById('miniDistance').textContent = '0 m';
       const prog = document.getElementById('miniProgress');
       const bar = document.getElementById('miniProgressBar');
-      prog.style.display = 'block';
+      prog.style.display = 'none';
       bar.style.width = '100%';
       clearInterval(miniInterval);
-      const end = startTime + duration;
-      miniInterval = setInterval(() => {
-        const remain = Math.max(0, end - Date.now());
-        bar.style.width = (remain / duration * 100) + '%';
-        if (remain <= 0) clearInterval(miniInterval);
-      }, 100);
+      clearInterval(miniCountdownTimer);
+      if (countdown > 0) {
+        const cd = document.getElementById('miniCountdown');
+        cd.style.display = 'block';
+        let remain = Math.ceil((startTime - Date.now()) / 1000);
+        cd.textContent = remain;
+        miniCountdownTimer = setInterval(() => {
+          remain--;
+          if (remain > 0) {
+            cd.textContent = remain;
+          } else {
+            clearInterval(miniCountdownTimer);
+            cd.style.display = 'none';
+            beginRun();
+          }
+        }, 1000);
+      } else {
+        beginRun();
+      }
+
+      function beginRun() {
+        miniGameReady = true;
+        const end = startTime + duration;
+        prog.style.display = 'block';
+        miniInterval = setInterval(() => {
+          const remainTime = Math.max(0, end - Date.now());
+          bar.style.width = (remainTime / duration * 100) + '%';
+          if (remainTime <= 0) clearInterval(miniInterval);
+        }, 100);
+      }
     });
 
-    document.getElementById('runLeft').onclick = () => {
-      if (lastRun !== 'left') {
+    function handleRun(dir) {
+      if (!miniGameReady) return;
+      if (lastRun !== dir) {
         socket.emit('miniGameTap', { roomCode });
-        lastRun = 'left';
+        lastRun = dir;
       }
-    };
-    document.getElementById('runRight').onclick = () => {
-      if (lastRun !== 'right') {
-        socket.emit('miniGameTap', { roomCode });
-        lastRun = 'right';
-      }
-    };
+    }
+
+    document.getElementById('runLeft').onclick = () => handleRun('left');
+    document.getElementById('runRight').onclick = () => handleRun('right');
+
+    document.addEventListener('keydown', (e) => {
+      if (!miniGameActive) return;
+      if (e.key === 'ArrowLeft') handleRun('left');
+      if (e.key === 'ArrowRight') handleRun('right');
+    });
 
     socket.on('miniGameDistance', ({ distance }) => {
       runDistance = distance;
@@ -221,6 +254,8 @@
         document.getElementById('game').style.display = 'block';
         res.textContent = '';
         miniGameActive = false;
+        miniGameReady = false;
+        clearInterval(miniCountdownTimer);
         if (hasAnswered) {
           document.getElementById('standingsPanel').style.display = 'block';
         }

--- a/public/player.html
+++ b/public/player.html
@@ -36,6 +36,7 @@
       </div>
       <button id="runLeft" style="width:45%; display:inline-block;">Left</button>
       <button id="runRight" style="width:45%; display:inline-block;">Right</button>
+      <div id="miniDistance">0 m</div>
       <div id="miniResult"></div>
     </div>
     <button id="buzz" class="buzz-btn">Buzz!</button>
@@ -50,6 +51,7 @@
     let hasAnswered = false;
     let lastRun = null;
     let miniGameActive = false;
+    let runDistance = 0;
 
     socket.on('scores', list => {
       const me = list.find(s => s.id === socket.id);
@@ -173,6 +175,8 @@
       mg.style.display = 'block';
       lastRun = null;
       miniGameActive = true;
+       runDistance = 0;
+       document.getElementById('miniDistance').textContent = '0 m';
       const prog = document.getElementById('miniProgress');
       const bar = document.getElementById('miniProgressBar');
       prog.style.display = 'block';
@@ -198,6 +202,11 @@
         lastRun = 'right';
       }
     };
+
+    socket.on('miniGameDistance', ({ distance }) => {
+      runDistance = distance;
+      document.getElementById('miniDistance').textContent = distance + ' m';
+    });
 
     socket.on('miniGameEnd', ({ winner }) => {
       clearInterval(miniInterval);

--- a/public/player.html
+++ b/public/player.html
@@ -10,6 +10,10 @@
 <body>
   <div id="roomCodeDisplay" class="room-code" style="display:none;"></div>
   <div id="playerScore" class="player-score" style="display:none;"></div>
+  <div id="standingsPanel" class="side-panel" style="display:none;">
+    <h3>Standings</h3>
+    <ul id="standingsList"></ul>
+  </div>
   <div id="submittedMsg" class="submitted-msg" style="display:none;">Question has been submitted.</div>
   <div class="container">
     <div id="join" class="question-block">
@@ -20,8 +24,19 @@
     <div id="game" style="display:none; position:relative; padding-top:60px;">
       <div id="category" class="category-tag" style="left:10px; right:auto; position:fixed; display:none;"></div>
       <div id="question" class="question-block question-display"></div>
-      <div id="progress" class="progress-container" style="display:none;"><div id="progressBar" class="progress-bar"></div></div>
+      <div id="progress" class="progress-container" style="display:none;">
+        <div id="progressBar" class="progress-bar"></div>
+      </div>
       <div id="options" class="options-list" style="display:none;"></div>
+    </div>
+    <div id="miniGame" class="question-block" style="display:none; text-align:center;">
+      <h2>Run!</h2>
+      <div id="miniProgress" class="progress-container" style="display:none;">
+        <div id="miniProgressBar" class="progress-bar"></div>
+      </div>
+      <button id="runLeft" style="width:45%; display:inline-block;">Left</button>
+      <button id="runRight" style="width:45%; display:inline-block;">Right</button>
+      <div id="miniResult"></div>
     </div>
     <button id="buzz" class="buzz-btn">Buzz!</button>
   </div>
@@ -31,6 +46,10 @@
     let roomCode = null;
     let selectedAnswer = null;
     let progressInterval = null;
+    let miniInterval = null;
+    let hasAnswered = false;
+    let lastRun = null;
+    let miniGameActive = false;
 
     socket.on('scores', list => {
       const me = list.find(s => s.id === socket.id);
@@ -38,6 +57,16 @@
         const sd = document.getElementById('playerScore');
         sd.textContent = 'Score: ' + me.score;
         sd.style.display = 'block';
+      }
+      const ul = document.getElementById('standingsList');
+      ul.innerHTML = '';
+      list.forEach(s => {
+        const li = document.createElement('li');
+        li.textContent = s.name + ': ' + s.score;
+        ul.appendChild(li);
+      });
+      if (hasAnswered && !miniGameActive) {
+        document.getElementById('standingsPanel').style.display = 'block';
       }
     });
 
@@ -57,6 +86,9 @@
 
     socket.on('question', q => {
       selectedAnswer = null;
+      hasAnswered = false;
+      document.getElementById('standingsPanel').style.display = 'none';
+      document.getElementById('miniGame').style.display = 'none';
       const cat = document.getElementById('category');
       cat.textContent = q.category;
       cat.style.display = 'block';
@@ -87,11 +119,13 @@
       const bar = document.getElementById('progressBar');
       if (q.timeLimit) {
         prog.style.display='block';
-        const end = q.startTime + q.timeLimit;
+        bar.style.width = '100%';
+        const duration = q.timeLimit;
+        const end = q.startTime + duration;
         clearInterval(progressInterval);
         progressInterval = setInterval(()=>{
           const remain = Math.max(0, end - Date.now());
-          bar.style.width = (remain / q.timeLimit * 100) + '%';
+          bar.style.width = (remain / duration * 100) + '%';
           if (remain <= 0) clearInterval(progressInterval);
         },100);
       } else {
@@ -108,6 +142,7 @@
         document.getElementById('options').style.display='none';
         btn.style.display='none';
         document.getElementById('submittedMsg').style.display = 'block';
+        hasAnswered = true;
       }
     };
 
@@ -126,6 +161,58 @@
 
     socket.on('roomClosed', () => {
       alert('Room closed');
+    });
+
+    socket.on('miniGameStart', ({ duration, startTime }) => {
+      document.getElementById('game').style.display = 'none';
+      document.getElementById('standingsPanel').style.display = 'none';
+      const mg = document.getElementById('miniGame');
+      mg.style.display = 'block';
+      lastRun = null;
+      miniGameActive = true;
+      const prog = document.getElementById('miniProgress');
+      const bar = document.getElementById('miniProgressBar');
+      prog.style.display = 'block';
+      bar.style.width = '100%';
+      clearInterval(miniInterval);
+      const end = startTime + duration;
+      miniInterval = setInterval(() => {
+        const remain = Math.max(0, end - Date.now());
+        bar.style.width = (remain / duration * 100) + '%';
+        if (remain <= 0) clearInterval(miniInterval);
+      }, 100);
+    });
+
+    document.getElementById('runLeft').onclick = () => {
+      if (lastRun !== 'left') {
+        socket.emit('miniGameTap', { roomCode });
+        lastRun = 'left';
+      }
+    };
+    document.getElementById('runRight').onclick = () => {
+      if (lastRun !== 'right') {
+        socket.emit('miniGameTap', { roomCode });
+        lastRun = 'right';
+      }
+    };
+
+    socket.on('miniGameEnd', ({ winner }) => {
+      clearInterval(miniInterval);
+      const res = document.getElementById('miniResult');
+      if (winner) {
+        res.textContent = winner.name + ' wins!';
+      } else {
+        res.textContent = 'No winner';
+      }
+      setTimeout(() => {
+        document.getElementById('miniGame').style.display = 'none';
+        document.getElementById('game').style.display = 'block';
+        res.textContent = '';
+        miniGameActive = false;
+        if (hasAnswered) {
+          document.getElementById('standingsPanel').style.display = 'block';
+        }
+      }, 2000);
     });
   </script>
 </body>

--- a/public/player.html
+++ b/public/player.html
@@ -126,7 +126,10 @@
         progressInterval = setInterval(()=>{
           const remain = Math.max(0, end - Date.now());
           bar.style.width = (remain / duration * 100) + '%';
-          if (remain <= 0) clearInterval(progressInterval);
+          if (remain <= 0) {
+            clearInterval(progressInterval);
+            disableAnswering();
+          }
         },100);
       } else {
         prog.style.display='none';
@@ -213,6 +216,23 @@
           document.getElementById('standingsPanel').style.display = 'block';
         }
       }, 2000);
+    });
+
+    function disableAnswering() {
+      const optsDiv = document.getElementById('options');
+      optsDiv.style.pointerEvents = 'none';
+      const buzz = document.getElementById('buzz');
+      buzz.disabled = true;
+      if (!hasAnswered) {
+        document.getElementById('submittedMsg').textContent = "Time's up!";
+        document.getElementById('submittedMsg').style.display = 'block';
+        hasAnswered = true;
+        document.getElementById('standingsPanel').style.display = 'block';
+      }
+    }
+
+    socket.on('timeUp', () => {
+      disableAnswering();
     });
   </script>
 </body>

--- a/public/style.css
+++ b/public/style.css
@@ -240,6 +240,11 @@ input, textarea, select {
   text-align: center;
 }
 
+.countdown {
+  font-size: 4rem;
+  font-weight: bold;
+}
+
 @media (max-width: 600px) {
   body { padding: 0.5rem; }
 }

--- a/public/style.css
+++ b/public/style.css
@@ -104,8 +104,10 @@ input, textarea, select {
   bottom: 20px;
   left: 50%;
   transform: translateX(-50%);
-  width: 80%;
-  max-width: 400px;
+  width: 90%;
+  max-width: none;
+  font-size: 2.5rem;
+  padding: 1.5rem 0;
 }
 
 .category-tag {
@@ -119,18 +121,23 @@ input, textarea, select {
 }
 
 .question-display {
-  font-size: 1.5rem;
+  font-size: 2rem;
   font-weight: bold;
   text-align: center;
   background: rgba(255,255,255,0.1);
   border-radius: 8px;
+  margin: 1rem auto;
 }
 
 .presentation .question-display {
-  font-size: 4rem;
-  padding: 0.5rem 1rem;
+  font-size: 5rem;
+  padding: 1rem 2rem;
   display: inline-block;
-  margin-top: 1rem;
+  margin-top: 2rem;
+  background: linear-gradient(90deg, var(--accent), var(--accent-hover));
+  -webkit-background-clip: text;
+  color: transparent;
+  text-shadow: 0 0 10px rgba(10,132,255,0.5);
 }
 
 .options-list .option {

--- a/server.js
+++ b/server.js
@@ -31,6 +31,46 @@ function emitScores(roomCode) {
   io.to(roomCode).emit('scores', scores);
 }
 
+function startMiniGame(roomCode) {
+  const room = rooms[roomCode];
+  if (!room) return;
+  const duration = 5000; // 5 seconds
+  room.miniGame = {
+    start: Date.now(),
+    duration,
+    counts: {}
+  };
+  io.to(roomCode).emit('miniGameStart', {
+    startTime: room.miniGame.start,
+    duration
+  });
+  room.miniGameTimer = setTimeout(() => endMiniGame(roomCode), duration);
+}
+
+function endMiniGame(roomCode) {
+  const room = rooms[roomCode];
+  if (!room || !room.miniGame) return;
+  const counts = room.miniGame.counts;
+  let winnerId = null;
+  let max = -1;
+  for (const [id, count] of Object.entries(counts)) {
+    if (count > max) {
+      max = count;
+      winnerId = id;
+    }
+  }
+  let winner = null;
+  if (winnerId && room.players[winnerId]) {
+    room.players[winnerId].score += 1;
+    winner = { id: winnerId, name: room.players[winnerId].name, count: max };
+  }
+  emitScores(roomCode);
+  io.to(roomCode).emit('miniGameEnd', { winner });
+  clearTimeout(room.miniGameTimer);
+  room.miniGame = null;
+  room.miniGameTimer = null;
+}
+
 function generateRoomCode() {
   return Math.random().toString(36).substring(2, 6).toUpperCase();
 }
@@ -46,7 +86,10 @@ io.on('connection', socket => {
       players: {},
       categories: [],
       remaining: [],
-      current: null
+      current: null,
+      questionCount: 0,
+      miniGame: null,
+      miniGameTimer: null
     };
     socket.join(code);
     socket.emit('roomCreated', code);
@@ -144,6 +187,7 @@ io.on('connection', socket => {
     room.current = { ci: sel.ci, qi: sel.qi, options, answer };
     room.questionStart = Date.now();
     room.timeLimit = timeLimit ? timeLimit * 1000 : null;
+    room.questionCount = (room.questionCount || 0) + 1;
 
     Object.values(room.players).forEach(p => {
       p.answered = false;
@@ -253,18 +297,31 @@ io.on('connection', socket => {
     const allAnswered = Object.values(room.players).every(p => p.answered);
     if (allAnswered) {
       io.to(room.admin).emit('allAnswered');
+      if (room.questionCount % 5 === 0) {
+        startMiniGame(roomCode);
+      }
     }
+  });
+
+  socket.on('miniGameTap', ({ roomCode }) => {
+    const room = rooms[roomCode];
+    if (!room || !room.miniGame) return;
+    room.miniGame.counts[socket.id] = (room.miniGame.counts[socket.id] || 0) + 1;
   });
 
   socket.on('disconnect', () => {
     for (const [code, room] of Object.entries(rooms)) {
       if (room.players[socket.id]) {
         delete room.players[socket.id];
+        if (room.miniGame && room.miniGame.counts) {
+          delete room.miniGame.counts[socket.id];
+        }
         emitPlayers(code);
         emitScores(code);
       }
       if (room.admin === socket.id) {
         io.to(code).emit('roomClosed');
+        if (room.miniGameTimer) clearTimeout(room.miniGameTimer);
         delete rooms[code];
       }
     }

--- a/server.js
+++ b/server.js
@@ -31,10 +31,30 @@ function emitScores(roomCode) {
   io.to(roomCode).emit('scores', scores);
 }
 
+function handleTimeUp(roomCode) {
+  const room = rooms[roomCode];
+  if (!room || !room.current) return;
+  Object.values(room.players).forEach(p => {
+    if (!p.answered) {
+      p.answered = true;
+      p.answer = null;
+      p.correct = false;
+      p.time = room.timeLimit;
+    }
+  });
+  room.questionTimer = null;
+  io.to(roomCode).emit('timeUp');
+  if (room.questionCount % 5 === 0) {
+    startMiniGame(roomCode);
+  } else if (room.remaining.length > 0 && room.lastSettings) {
+    setTimeout(() => startQuestion(roomCode, room.lastSettings.randomize, room.lastSettings.timeLimit), 3000);
+  }
+}
+
 function startMiniGame(roomCode) {
   const room = rooms[roomCode];
   if (!room) return;
-  const duration = 5000; // 5 seconds
+  const duration = 10000; // 10 seconds
   room.miniGame = {
     start: Date.now(),
     duration,
@@ -104,6 +124,12 @@ function startQuestion(roomCode, randomize, timeLimit) {
   room.current = { ci: sel.ci, qi: sel.qi, options, answer };
   room.questionStart = Date.now();
   room.timeLimit = timeLimit ? timeLimit * 1000 : null;
+  if (room.questionTimer) clearTimeout(room.questionTimer);
+  if (room.timeLimit) {
+    room.questionTimer = setTimeout(() => handleTimeUp(roomCode), room.timeLimit);
+  } else {
+    room.questionTimer = null;
+  }
   room.questionCount = (room.questionCount || 0) + 1;
 
   Object.values(room.players).forEach(p => {
@@ -294,6 +320,10 @@ io.on('connection', socket => {
       console.warn(`playerAnswer: player ${socket.id} already answered`);
       return;
     }
+    if (room.timeLimit && Date.now() - room.questionStart > room.timeLimit) {
+      console.warn('playerAnswer: answer after time up');
+      return;
+    }
     const correct = answer === room.current.answer;
     player.answered = true;
     player.answer = answer;
@@ -304,6 +334,7 @@ io.on('connection', socket => {
     emitScores(roomCode);
     const allAnswered = Object.values(room.players).every(p => p.answered);
     if (allAnswered) {
+      if (room.questionTimer) { clearTimeout(room.questionTimer); room.questionTimer = null; }
       if (room.questionCount % 5 === 0) {
         startMiniGame(roomCode);
       } else if (room.remaining.length > 0 && room.lastSettings) {

--- a/server.js
+++ b/server.js
@@ -55,17 +55,19 @@ function handleTimeUp(roomCode) {
 function startMiniGame(roomCode) {
   const room = rooms[roomCode];
   if (!room || room.miniGame) return;
-  const duration = 10000; // 10 seconds
+  const countdown = 3000; // 3 second countdown
+  const duration = 10000; // 10 seconds of running
   room.miniGame = {
-    start: Date.now(),
+    start: Date.now() + countdown,
     duration,
     counts: {}
   };
   io.to(roomCode).emit('miniGameStart', {
     startTime: room.miniGame.start,
-    duration
+    duration,
+    countdown
   });
-  room.miniGameTimer = setTimeout(() => endMiniGame(roomCode), duration);
+  room.miniGameTimer = setTimeout(() => endMiniGame(roomCode), countdown + duration);
 }
 
 function endMiniGame(roomCode, forcedWinnerId = null) {

--- a/server.js
+++ b/server.js
@@ -69,10 +69,57 @@ function endMiniGame(roomCode) {
   clearTimeout(room.miniGameTimer);
   room.miniGame = null;
   room.miniGameTimer = null;
+  if (room.remaining.length > 0 && room.lastSettings) {
+    setTimeout(() => startQuestion(roomCode, room.lastSettings.randomize, room.lastSettings.timeLimit), 3000);
+  }
 }
 
 function generateRoomCode() {
   return Math.random().toString(36).substring(2, 6).toUpperCase();
+}
+
+function startQuestion(roomCode, randomize, timeLimit) {
+  const room = rooms[roomCode];
+  if (!room || room.remaining.length === 0) {
+    console.error(`startQuestion: room ${roomCode} not found or no questions remaining`);
+    return;
+  }
+  room.lastSettings = { randomize, timeLimit };
+  const idx = Math.floor(Math.random() * room.remaining.length);
+  const sel = room.remaining.splice(idx, 1)[0];
+  const q = room.categories[sel.ci].questions[sel.qi];
+
+  let options = [...q.options];
+  let answer = q.answer;
+  if (randomize) {
+    const arr = options.map((o, i) => ({ o, i }));
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    options = arr.map(a => a.o);
+    answer = arr.findIndex(a => a.i === q.answer);
+  }
+
+  room.current = { ci: sel.ci, qi: sel.qi, options, answer };
+  room.questionStart = Date.now();
+  room.timeLimit = timeLimit ? timeLimit * 1000 : null;
+  room.questionCount = (room.questionCount || 0) + 1;
+
+  Object.values(room.players).forEach(p => {
+    p.answered = false;
+    p.answer = null;
+    p.correct = null;
+    p.time = null;
+  });
+
+  io.to(roomCode).emit('question', {
+    category: room.categories[sel.ci].name,
+    text: q.text,
+    options,
+    timeLimit: room.timeLimit,
+    startTime: room.questionStart
+  });
 }
 
 io.on('connection', socket => {
@@ -163,46 +210,7 @@ io.on('connection', socket => {
   });
 
   socket.on('adminStartQuestion', ({ roomCode, randomize, timeLimit }) => {
-    const room = rooms[roomCode];
-    if (!room || room.remaining.length === 0) {
-      console.error(`adminStartQuestion: room ${roomCode} not found or no questions remaining`);
-      return;
-    }
-    const idx = Math.floor(Math.random() * room.remaining.length);
-    const sel = room.remaining.splice(idx, 1)[0];
-    const q = room.categories[sel.ci].questions[sel.qi];
-
-    let options = [...q.options];
-    let answer = q.answer;
-    if (randomize) {
-      const arr = options.map((o, i) => ({ o, i }));
-      for (let i = arr.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [arr[i], arr[j]] = [arr[j], arr[i]];
-      }
-      options = arr.map(a => a.o);
-      answer = arr.findIndex(a => a.i === q.answer);
-    }
-
-    room.current = { ci: sel.ci, qi: sel.qi, options, answer };
-    room.questionStart = Date.now();
-    room.timeLimit = timeLimit ? timeLimit * 1000 : null;
-    room.questionCount = (room.questionCount || 0) + 1;
-
-    Object.values(room.players).forEach(p => {
-      p.answered = false;
-      p.answer = null;
-      p.correct = null;
-      p.time = null;
-    });
-
-    io.to(roomCode).emit('question', {
-      category: room.categories[sel.ci].name,
-      text: q.text,
-      options,
-      timeLimit: room.timeLimit,
-      startTime: room.questionStart
-    });
+    startQuestion(roomCode, randomize, timeLimit);
   });
 
   socket.on('playerJoin', ({ roomCode, name }) => {
@@ -296,9 +304,10 @@ io.on('connection', socket => {
     emitScores(roomCode);
     const allAnswered = Object.values(room.players).every(p => p.answered);
     if (allAnswered) {
-      io.to(room.admin).emit('allAnswered');
       if (room.questionCount % 5 === 0) {
         startMiniGame(roomCode);
+      } else if (room.remaining.length > 0 && room.lastSettings) {
+        setTimeout(() => startQuestion(roomCode, room.lastSettings.randomize, room.lastSettings.timeLimit), 3000);
       }
     }
   });

--- a/server.js
+++ b/server.js
@@ -68,17 +68,21 @@ function startMiniGame(roomCode) {
   room.miniGameTimer = setTimeout(() => endMiniGame(roomCode), duration);
 }
 
-function endMiniGame(roomCode) {
+function endMiniGame(roomCode, forcedWinnerId = null) {
   const room = rooms[roomCode];
   if (!room || !room.miniGame) return;
   const counts = room.miniGame.counts;
-  let winnerId = null;
+  let winnerId = forcedWinnerId;
   let max = -1;
-  for (const [id, count] of Object.entries(counts)) {
-    if (count > max) {
-      max = count;
-      winnerId = id;
+  if (!winnerId) {
+    for (const [id, count] of Object.entries(counts)) {
+      if (count > max) {
+        max = count;
+        winnerId = id;
+      }
     }
+  } else {
+    max = counts[winnerId] || 0;
   }
   let winner = null;
   if (winnerId && room.players[winnerId]) {
@@ -348,7 +352,12 @@ io.on('connection', socket => {
   socket.on('miniGameTap', ({ roomCode }) => {
     const room = rooms[roomCode];
     if (!room || !room.miniGame) return;
-    room.miniGame.counts[socket.id] = (room.miniGame.counts[socket.id] || 0) + 1;
+    const newCount = (room.miniGame.counts[socket.id] || 0) + 1;
+    room.miniGame.counts[socket.id] = newCount;
+    io.to(socket.id).emit('miniGameDistance', { distance: newCount });
+    if (newCount >= 100) {
+      endMiniGame(roomCode, socket.id);
+    }
   });
 
   socket.on('disconnect', () => {

--- a/server.js
+++ b/server.js
@@ -42,6 +42,7 @@ function handleTimeUp(roomCode) {
       p.time = room.timeLimit;
     }
   });
+  room.current = null;
   room.questionTimer = null;
   io.to(roomCode).emit('timeUp');
   if (room.questionCount % 5 === 0) {
@@ -53,7 +54,7 @@ function handleTimeUp(roomCode) {
 
 function startMiniGame(roomCode) {
   const room = rooms[roomCode];
-  if (!room) return;
+  if (!room || room.miniGame) return;
   const duration = 10000; // 10 seconds
   room.miniGame = {
     start: Date.now(),
@@ -335,6 +336,7 @@ io.on('connection', socket => {
     const allAnswered = Object.values(room.players).every(p => p.answered);
     if (allAnswered) {
       if (room.questionTimer) { clearTimeout(room.questionTimer); room.questionTimer = null; }
+      room.current = null;
       if (room.questionCount % 5 === 0) {
         startMiniGame(roomCode);
       } else if (room.remaining.length > 0 && room.lastSettings) {


### PR DESCRIPTION
## Summary
- Display per-question countdown bar that reflects the admin-configured timer.
- Show a live standings panel to players after they submit an answer.
- Launch a tap-based mini-game every five questions; winner earns an extra point.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd63e01df8832ba2f39c3560ecc2f2