### PR TITLE
Add run game toggle and improve player button behavior

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -26,6 +26,7 @@
         <select id="savedSetups"></select>
       </div>
       <label><input type="checkbox" id="randomize"> Randomize answers</label>
+      <label><input type="checkbox" id="includeRun" checked> Include Run Game</label>
       <input id="timeLimit" type="number" placeholder="Time limit (seconds)">
       <button id="nextQuestion" style="display:none;">Start Question</button>
     </div>
@@ -145,7 +146,8 @@
     document.getElementById('nextQuestion').onclick = () => {
       const randomize = document.getElementById('randomize').checked;
       const tl = parseInt(document.getElementById('timeLimit').value, 10);
-      socket.emit('adminStartQuestion', { roomCode, randomize, timeLimit: isNaN(tl) ? null : tl });
+      const includeRun = document.getElementById('includeRun').checked;
+      socket.emit('adminStartQuestion', { roomCode, randomize, timeLimit: isNaN(tl) ? null : tl, includeRun });
       document.getElementById('nextQuestion').style.display = 'none';
     };
 

--- a/public/player.html
+++ b/public/player.html
@@ -103,6 +103,7 @@
       const optsDiv = document.getElementById('options');
       optsDiv.style.display='none';
       optsDiv.innerHTML='';
+      optsDiv.style.pointerEvents='auto';
       q.options.forEach((opt, idx) => {
         const btn = document.createElement('button');
         btn.textContent = opt;

--- a/public/style.css
+++ b/public/style.css
@@ -108,6 +108,11 @@ input, textarea, select {
   max-width: none;
   font-size: 2.5rem;
   padding: 1.5rem 0;
+  transition: none;
+}
+
+.buzz-btn:active {
+  transform: translateX(-50%);
 }
 
 .category-tag {

--- a/server.js
+++ b/server.js
@@ -45,7 +45,7 @@ function handleTimeUp(roomCode) {
   room.current = null;
   room.questionTimer = null;
   io.to(roomCode).emit('timeUp');
-  if (room.questionCount % 5 === 0) {
+  if (room.includeRunGame && room.questionCount % 5 === 0) {
     startMiniGame(roomCode);
   } else if (room.remaining.length > 0 && room.lastSettings) {
     setTimeout(() => startQuestion(roomCode, room.lastSettings.randomize, room.lastSettings.timeLimit), 3000);
@@ -169,7 +169,8 @@ io.on('connection', socket => {
       current: null,
       questionCount: 0,
       miniGame: null,
-      miniGameTimer: null
+      miniGameTimer: null,
+      includeRunGame: true
     };
     socket.join(code);
     socket.emit('roomCreated', code);
@@ -242,7 +243,9 @@ io.on('connection', socket => {
     }
   });
 
-  socket.on('adminStartQuestion', ({ roomCode, randomize, timeLimit }) => {
+  socket.on('adminStartQuestion', ({ roomCode, randomize, timeLimit, includeRun }) => {
+    const room = rooms[roomCode];
+    if (room) room.includeRunGame = includeRun;
     startQuestion(roomCode, randomize, timeLimit);
   });
 
@@ -343,7 +346,7 @@ io.on('connection', socket => {
     if (allAnswered) {
       if (room.questionTimer) { clearTimeout(room.questionTimer); room.questionTimer = null; }
       room.current = null;
-      if (room.questionCount % 5 === 0) {
+      if (room.includeRunGame && room.questionCount % 5 === 0) {
         startMiniGame(roomCode);
       } else if (room.remaining.length > 0 && room.lastSettings) {
         setTimeout(() => startQuestion(roomCode, room.lastSettings.randomize, room.lastSettings.timeLimit), 3000);


### PR DESCRIPTION
## Summary
- Allow admins to enable/disable the run mini-game via new checkbox
- Fix players getting locked out of answering by resetting option interactivity
- Simplify Buzz/Submit button styling to remove jump animation

## Testing
- `node --check server.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd97b6f174832ba0be8ed3965e6b8d