### PR TITLE
Batch mini-game input and add polling fallback

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -45,7 +45,8 @@
   </div>
   <script src="/socket.io/socket.io.js"></script>
   <script>
-    const socket = io();
+    // Try websockets first; fall back to polling if unavailable
+    const socket = io({ transports: ['websocket', 'polling'] });
     let roomCode = null;
     let selectedAnswer = null;
     let progressInterval = null;
@@ -56,6 +57,8 @@
     let runDistance = 0;
     let miniGameReady = false;
     let miniCountdownTimer = null;
+    let pendingTaps = 0;
+    let tapTimer = null;
 
     socket.on('scores', list => {
       const me = list.find(s => s.id === socket.id);
@@ -220,11 +223,22 @@
       }
     });
 
+    function sendTapBatch() {
+      socket.emit('miniGameTapBatch', { roomCode, count: pendingTaps });
+      pendingTaps = 0;
+      tapTimer = null;
+    }
+
     function handleRun(dir) {
       if (!miniGameReady) return;
       if (lastRun !== dir) {
-        socket.emit('miniGameTap', { roomCode });
         lastRun = dir;
+        pendingTaps++;
+        runDistance++;
+        document.getElementById('miniDistance').textContent = runDistance + ' m';
+        if (!tapTimer) {
+          tapTimer = setTimeout(sendTapBatch, 100);
+        }
       }
     }
 

--- a/server.js
+++ b/server.js
@@ -361,10 +361,10 @@ io.on('connection', socket => {
     }
   });
 
-  socket.on('miniGameTap', ({ roomCode }) => {
+  function handleMiniGameTap(roomCode, count = 1) {
     const room = rooms[roomCode];
-    if (!room || !room.miniGame) return;
-    const newCount = (room.miniGame.counts[socket.id] || 0) + 1;
+    if (!room || !room.miniGame || !count) return;
+    const newCount = (room.miniGame.counts[socket.id] || 0) + count;
     room.miniGame.counts[socket.id] = newCount;
     const player = room.players[socket.id];
     io.to(socket.id).emit('miniGameDistance', { distance: newCount });
@@ -374,7 +374,11 @@ io.on('connection', socket => {
     if (newCount >= 100) {
       endMiniGame(roomCode, socket.id);
     }
-  });
+  }
+
+  socket.on('miniGameTap', ({ roomCode }) => handleMiniGameTap(roomCode, 1));
+
+  socket.on('miniGameTapBatch', ({ roomCode, count }) => handleMiniGameTap(roomCode, count));
 
   socket.on('disconnect', () => {
     connectionCount = Math.max(0, connectionCount - 1);


### PR DESCRIPTION
## Summary
- batch mini game taps on the client and handle them server-side to reduce traffic
- attempt websockets first and fall back to polling transport if unavailable

## Testing
- `npm test`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68be09598b30832b92fec150a22b0745