### PR TITLE
Log high connection load and simplify player interface

### DIFF
--- a/public/answer.html
+++ b/public/answer.html
@@ -31,9 +31,7 @@
   <script src="/socket.io/socket.io.js"></script>
   <script>
     const socket = io();
-    const letters = ['A','B','C','D'];
     let roomCode = null;
-    let currentOptions = [];
     let playerCount = 0;
     let answered = 0;
     let progressInterval = null;
@@ -59,7 +57,6 @@
       document.getElementById('answers').style.display = 'flex';
       document.getElementById('correctList').innerHTML='';
       document.getElementById('incorrectList').innerHTML='';
-      currentOptions = q.options;
       answered = 0;
       // progress bar
       const prog = document.getElementById('progress');
@@ -80,9 +77,8 @@
 
     socket.on('playerAnswered', data => {
       const li = document.createElement('li');
-      const text = currentOptions[data.answer] || letters[data.answer];
       const secs = (data.time/1000).toFixed(2) + 's';
-      li.textContent = data.name + ': ' + text;
+      li.textContent = data.name;
       const chip = document.createElement('span');
       chip.className='time-chip';
       chip.textContent=secs;

--- a/public/player.html
+++ b/public/player.html
@@ -10,10 +10,6 @@
 <body>
   <div id="roomCodeDisplay" class="room-code" style="display:none;"></div>
   <div id="playerScore" class="player-score" style="display:none;"></div>
-  <div id="standingsPanel" class="side-panel" style="display:none;">
-    <h3>Standings</h3>
-    <ul id="standingsList"></ul>
-  </div>
   <div id="submittedMsg" class="submitted-msg" style="display:none;">Question has been submitted.</div>
   <div class="container">
     <div id="join" class="question-block">
@@ -67,16 +63,6 @@
         sd.textContent = 'Score: ' + me.score;
         sd.style.display = 'block';
       }
-      const ul = document.getElementById('standingsList');
-      ul.innerHTML = '';
-      list.forEach(s => {
-        const li = document.createElement('li');
-        li.textContent = s.name + ': ' + s.score;
-        ul.appendChild(li);
-      });
-      if (hasAnswered && !miniGameActive) {
-        document.getElementById('standingsPanel').style.display = 'block';
-      }
     });
 
     document.getElementById('joinBtn').onclick = () => {
@@ -96,7 +82,6 @@
     socket.on('question', q => {
       selectedAnswer = null;
       hasAnswered = false;
-      document.getElementById('standingsPanel').style.display = 'none';
       document.getElementById('miniGame').style.display = 'none';
       const cat = document.getElementById('category');
       cat.textContent = q.category;
@@ -178,7 +163,6 @@
 
     socket.on('miniGameStart', ({ duration, startTime, countdown = 0 }) => {
       document.getElementById('game').style.display = 'none';
-      document.getElementById('standingsPanel').style.display = 'none';
       const mg = document.getElementById('miniGame');
       mg.style.display = 'block';
       lastRun = null;
@@ -271,9 +255,6 @@
         miniGameActive = false;
         miniGameReady = false;
         clearInterval(miniCountdownTimer);
-        if (hasAnswered) {
-          document.getElementById('standingsPanel').style.display = 'block';
-        }
       }, 2000);
     });
 
@@ -286,7 +267,6 @@
         document.getElementById('submittedMsg').textContent = "Time's up!";
         document.getElementById('submittedMsg').style.display = 'block';
         hasAnswered = true;
-        document.getElementById('standingsPanel').style.display = 'block';
       }
     }
 

--- a/server.js
+++ b/server.js
@@ -11,6 +11,15 @@ app.use(express.static('public'));
 const rooms = {};
 const MAX_CONNECTIONS = parseInt(process.env.MAX_CONNECTIONS, 10) || 100;
 let connectionCount = 0;
+const WARNING_RATIO = 0.8;
+
+function logConnectionStatus(action) {
+  const usage = `${connectionCount}/${MAX_CONNECTIONS}`;
+  console.log(`${action}: ${usage}`);
+  if (connectionCount / MAX_CONNECTIONS >= WARNING_RATIO) {
+    console.warn(`High connection load: ${usage}`);
+  }
+}
 
 function getScores(room) {
   const scores = Object.entries(room.players).map(([id, p]) => ({ id, name: p.name, score: p.score }));
@@ -164,6 +173,7 @@ io.on('connection', socket => {
     return;
   }
   connectionCount++;
+  logConnectionStatus('connect');
   socket.on('adminCreateRoom', () => {
     let code;
     do {
@@ -382,6 +392,7 @@ io.on('connection', socket => {
 
   socket.on('disconnect', () => {
     connectionCount = Math.max(0, connectionCount - 1);
+    logConnectionStatus('disconnect');
     for (const [code, room] of Object.entries(rooms)) {
       if (room.players[socket.id]) {
         delete room.players[socket.id];


### PR DESCRIPTION
## Summary
- Log current connections and warn when usage exceeds 80% of capacity
- Remove player-side standings sidebar and show only personal score
- Hide players' chosen answers on answer screen, keeping names and times

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be2c56b98c832baa82769975a6ecc8