### PR TITLE
Ensure run game runs full duration with answer screen replay

### DIFF
--- a/public/answer.html
+++ b/public/answer.html
@@ -128,7 +128,7 @@
       }
     });
 
-    socket.on('miniGameEnd', ({ winner }) => {
+    socket.on('miniGameEnd', ({ winner, replay }) => {
       const track = document.getElementById('runGame');
       const msg = document.createElement('div');
       msg.className = 'lane-label';
@@ -136,8 +136,34 @@
       msg.textContent = winner ? (winner.name + ' wins!') : 'No winner';
       track.appendChild(msg);
       setTimeout(() => {
-        track.style.display = 'none';
         track.innerHTML = '';
+        replay.forEach(p => {
+          const lane = document.createElement('div');
+          lane.className = 'lane';
+          lane.innerHTML = '<div class="lane-label">'+p.name+'</div><img src="/images/run.gif" class="runner" id="replay_'+p.id+'">';
+          track.appendChild(lane);
+        });
+        const start = Date.now();
+        const duration = 12000;
+        function animate() {
+          const elapsed = Date.now() - start;
+          const pct = Math.min(elapsed / duration, 1);
+          replay.forEach(p => {
+            const runner = document.getElementById('replay_' + p.id);
+            const finalPct = Math.min(p.taps, 100) / 100 * 75;
+            runner.style.left = (pct * finalPct) + '%';
+          });
+          if (elapsed < duration) {
+            requestAnimationFrame(animate);
+          } else {
+            setTimeout(() => {
+              track.style.display = 'none';
+              track.innerHTML = '';
+              socket.emit('miniGameReplayFinished', { roomCode });
+            }, 1000);
+          }
+        }
+        animate();
       }, 2000);
     });
 

--- a/public/answer.html
+++ b/public/answer.html
@@ -120,14 +120,6 @@
       track.style.display = 'block';
     });
 
-    socket.on('miniGameUpdate', ({ id, distance }) => {
-      const runner = document.getElementById('runner_' + id);
-      if (runner) {
-        const pct = Math.min(distance, 100) / 100 * 75;
-        runner.style.left = pct + '%';
-      }
-    });
-
     socket.on('miniGameEnd', ({ winner, replay }) => {
       const track = document.getElementById('runGame');
       const msg = document.createElement('div');

--- a/public/player.html
+++ b/public/player.html
@@ -53,8 +53,6 @@
     let runDistance = 0;
     let miniGameReady = false;
     let miniCountdownTimer = null;
-    let pendingTaps = 0;
-    let tapTimer = null;
 
     socket.on('scores', list => {
       const me = list.find(s => s.id === socket.id);
@@ -205,32 +203,18 @@
           if (remainTime <= 0) {
             clearInterval(miniInterval);
             miniGameReady = false;
-            if (tapTimer) {
-              clearTimeout(tapTimer);
-              sendTapBatch();
-            }
             socket.emit('miniGameResult', { roomCode, taps: runDistance });
           }
         }, 100);
       }
     });
 
-    function sendTapBatch() {
-      socket.emit('miniGameTapBatch', { roomCode, count: pendingTaps });
-      pendingTaps = 0;
-      tapTimer = null;
-    }
-
     function handleRun(dir) {
       if (!miniGameReady) return;
       if (lastRun !== dir) {
         lastRun = dir;
-        pendingTaps++;
         runDistance++;
         document.getElementById('miniDistance').textContent = runDistance + ' m';
-        if (!tapTimer) {
-          tapTimer = setTimeout(sendTapBatch, 100);
-        }
       }
     }
 
@@ -241,11 +225,6 @@
       if (!miniGameActive) return;
       if (e.key === 'ArrowLeft') handleRun('left');
       if (e.key === 'ArrowRight') handleRun('right');
-    });
-
-    socket.on('miniGameDistance', ({ distance }) => {
-      runDistance = distance;
-      document.getElementById('miniDistance').textContent = distance + ' m';
     });
 
     socket.on('miniGameEnd', ({ winner }) => {

--- a/public/player.html
+++ b/public/player.html
@@ -202,7 +202,15 @@
         miniInterval = setInterval(() => {
           const remainTime = Math.max(0, end - Date.now());
           bar.style.width = (remainTime / duration * 100) + '%';
-          if (remainTime <= 0) clearInterval(miniInterval);
+          if (remainTime <= 0) {
+            clearInterval(miniInterval);
+            miniGameReady = false;
+            if (tapTimer) {
+              clearTimeout(tapTimer);
+              sendTapBatch();
+            }
+            socket.emit('miniGameResult', { roomCode, taps: runDistance });
+          }
         }, 100);
       }
     });

--- a/server.js
+++ b/server.js
@@ -67,7 +67,7 @@ function startRunGame(roomCode) {
   const room = rooms[roomCode];
   if (!room || room.miniGame) return;
   const countdown = 3000; // 3 second countdown
-  const duration = 10000; // 10 seconds of running
+  const duration = 12000; // 12 seconds of running
   room.miniGame = {
     type: 'run',
     start: Date.now() + countdown,
@@ -82,7 +82,8 @@ function startRunGame(roomCode) {
     duration,
     countdown
   });
-  room.miniGameTimer = setTimeout(() => endRunGame(roomCode), countdown + duration);
+  // small buffer to ensure clients can report final tap counts
+  room.miniGameTimer = setTimeout(() => endRunGame(roomCode), countdown + duration + 200);
 }
 
 function endRunGame(roomCode) {
@@ -91,31 +92,29 @@ function endRunGame(roomCode) {
   const counts = room.miniGame.counts;
   let winnerId = null;
   let max = -1;
-  for (const [id, count] of Object.entries(counts)) {
-    if (count > max) {
-      max = count;
+  for (const [id, taps] of Object.entries(counts)) {
+    if (taps > max) {
+      max = taps;
       winnerId = id;
     }
   }
   let winner = null;
   if (winnerId && room.players[winnerId]) {
     room.players[winnerId].score += 1;
-    winner = { id: winnerId, name: room.players[winnerId].name, count: max };
+    winner = { id: winnerId, name: room.players[winnerId].name, taps: max };
   }
   console.log(`[runGame] end in room ${roomCode} with ${room.miniGame.tapCount} taps`);
-  const replay = Object.entries(counts).map(([id, count]) => ({
+  const replay = Object.entries(counts).map(([id, taps]) => ({
     id,
     name: room.players[id] ? room.players[id].name : id,
-    count
+    taps
   }));
   emitScores(roomCode);
   io.to(roomCode).emit('miniGameEnd', { type: 'run', winner, replay });
   clearTimeout(room.miniGameTimer);
   room.miniGame = null;
   room.miniGameTimer = null;
-  if (room.remaining.length > 0 && room.lastSettings) {
-    setTimeout(() => startQuestion(roomCode, room.lastSettings.randomize, room.lastSettings.timeLimit), 3000);
-  }
+  room.awaitingReplay = true;
 }
 
 function startCoinTossGame(roomCode) {
@@ -429,6 +428,7 @@ io.on('connection', socket => {
     const newCount = (room.miniGame.counts[socket.id] || 0) + count;
     room.miniGame.counts[socket.id] = newCount;
     room.miniGame.tapCount += count;
+    io.to(roomCode).emit('miniGameUpdate', { id: socket.id, distance: newCount });
     console.log(`[runGame] tap from ${socket.id}, total taps: ${room.miniGame.tapCount}`);
   }
 
@@ -436,10 +436,29 @@ io.on('connection', socket => {
 
   socket.on('miniGameTapBatch', ({ roomCode, count }) => handleMiniGameTap(roomCode, count));
 
+  socket.on('miniGameResult', ({ roomCode, taps }) => {
+    const room = rooms[roomCode];
+    if (!room || !room.miniGame || room.miniGame.type !== 'run' || typeof taps !== 'number') return;
+    const prev = room.miniGame.counts[socket.id] || 0;
+    room.miniGame.counts[socket.id] = taps;
+    room.miniGame.tapCount += taps - prev;
+    io.to(roomCode).emit('miniGameUpdate', { id: socket.id, distance: taps });
+    console.log(`[runGame] result from ${socket.id}: ${taps} taps`);
+  });
+
   socket.on('coinTossChoice', ({ roomCode, choice }) => {
     const room = rooms[roomCode];
     if (!room || !room.miniGame || room.miniGame.type !== 'coinToss') return;
     room.miniGame.choices[socket.id] = choice;
+  });
+
+  socket.on('miniGameReplayFinished', ({ roomCode }) => {
+    const room = rooms[roomCode];
+    if (!room || !room.awaitingReplay) return;
+    room.awaitingReplay = false;
+    if (room.remaining.length > 0 && room.lastSettings) {
+      startQuestion(roomCode, room.lastSettings.randomize, room.lastSettings.timeLimit);
+    }
   });
 
   socket.on('disconnect', () => {

--- a/server.js
+++ b/server.js
@@ -422,27 +422,12 @@ io.on('connection', socket => {
     }
   });
 
-  function handleMiniGameTap(roomCode, count = 1) {
-    const room = rooms[roomCode];
-    if (!room || !room.miniGame || room.miniGame.type !== 'run' || !count) return;
-    const newCount = (room.miniGame.counts[socket.id] || 0) + count;
-    room.miniGame.counts[socket.id] = newCount;
-    room.miniGame.tapCount += count;
-    io.to(roomCode).emit('miniGameUpdate', { id: socket.id, distance: newCount });
-    console.log(`[runGame] tap from ${socket.id}, total taps: ${room.miniGame.tapCount}`);
-  }
-
-  socket.on('miniGameTap', ({ roomCode }) => handleMiniGameTap(roomCode, 1));
-
-  socket.on('miniGameTapBatch', ({ roomCode, count }) => handleMiniGameTap(roomCode, count));
-
   socket.on('miniGameResult', ({ roomCode, taps }) => {
     const room = rooms[roomCode];
     if (!room || !room.miniGame || room.miniGame.type !== 'run' || typeof taps !== 'number') return;
     const prev = room.miniGame.counts[socket.id] || 0;
     room.miniGame.counts[socket.id] = taps;
     room.miniGame.tapCount += taps - prev;
-    io.to(roomCode).emit('miniGameUpdate', { id: socket.id, distance: taps });
     console.log(`[runGame] result from ${socket.id}: ${taps} taps`);
   });
 


### PR DESCRIPTION
## Summary
- Capture each player's total taps at the end of the run game and send them to the server
- Use reported tap totals to build the run replay on the answer screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bec552ba24832ba83031ccf76e9243